### PR TITLE
Fix-01: DataReader stability + remove ribbon sheet activation

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,147 @@
+# CODEX OPERATING PROTOCOL — NYC AMI Calculator
+
+You are working in an existing production repository. Your job is to implement small, isolated fixes without breaking established logic.
+
+## Repo + Base Branch (must be explicit)
+- Repo: martin10101/nyc-ami-calculator
+- Base branch for all fixes: perf/api-optimize-speed-2026-02-05
+
+“Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
+
+## Golden Rules
+1) One fix per iteration. Do not combine fixes.
+2) Minimal diff. No refactors, renames, formatting sweeps, or dependency changes unless explicitly required.
+3) Preserve interfaces and Excel sheet structure unless the fix explicitly changes them.
+4) Do not change solver scoring/constraints unless the fix explicitly targets solver behavior.
+5) If you think you must touch >3 files, STOP and ask for approval.
+6) Never rely on ActiveSheet to locate MIH/UAP targets unless explicitly verified safe.
+
+## Required Workflow (every session)
+### Step 0 — Read the Ledger (required)
+Open docs/CODEX_LEDGER.md and identify:
+- the next unchecked fix in the queue,
+- the last completed fix,
+- any open risks or follow-ups.
+
+### Step 1 — Create a Branch
+Create a branch from the base branch:
+- fix/<ID>-<short-slug>
+
+### Step 2 — Produce a Task Card (before coding)
+Write a Task Card that includes:
+- Goal (2–4 bullets)
+- Success Criteria
+- Files to change (exact paths)
+- Functions/entrypoints to change
+- Proposed patch (logic-level description)
+- Risk pre-mortem (how this could break things + mitigations)
+- Test plan (exact steps)
+- Rollback plan
+
+Do not code until the Task Card is written.
+
+### Step 3 — Implement
+- Only implement what was proposed in the Task Card.
+- Keep changes localized.
+- Add/adjust tests only when lightweight and aligned with repo.
+
+### Step 4 — Verify
+- Run tests if possible.
+- If you cannot run tests, provide exact manual test steps and expected outputs.
+
+### Step 5 — GitHub Push + PR (required)
+After committing:
+1) Push the branch to origin.
+2) Open a draft PR targeting the base branch (perf/api-optimize-speed-2026-02-05).
+3) Put the Fix ID in the PR title (e.g., "Fix-04: Ribbon stays active").
+
+### Step 6 — Update Ledger (required)
+Update docs/CODEX_LEDGER.md with:
+- Repo + base branch
+- Work branch + commit SHA
+- PR number/link (or "no PR")
+- Files changed
+- Summary of changes
+- Tests run + results
+- Remaining notes/risks
+- Render deploy status (see below)
+Then STOP. Do not start the next fix.
+
+---
+
+## Render Deployment Rule (GitHub-backed service)
+We want deterministic deployments tied to a commit SHA, not branch-hopping.
+
+### Current setting (do not change)
+- Auto-deploy: OFF
+- Service ID: srv-d37n6her433s73et1bp0
+
+### Behavior required from Codex
+- Do NOT trigger deployments automatically.
+- Only record the ready-to-deploy commit SHA in docs/CODEX_LEDGER.md and tell the user which commit/PR to deploy.
+
+Preferred method (manual by user):
+- User deploys from Render dashboard when ready.
+Optional method (only if user provides deploy hook secret out-of-band):
+- Trigger deploy via Render deploy hook with `ref=<commit_sha>` (deploy specific commit).
+  - Note: deploying a specific commit may disable auto-deploys until reenabled. (Render docs)
+
+Render MCP note:
+- Render MCP currently does NOT support triggering deploys or modifying existing services (except env vars). Therefore do NOT rely on MCP for branch switching or deploy triggers. (Render docs)
+
+---
+
+## Known repo-specific findings (use these to guide safe fixes)
+### 1) Scenario apply uses cached DataSheet + AMI column
+- ApplyScenarioByKey(...) in excel-addin/src/AMI_Optix_ResultsWriter.bas calls GetDataSheet() and GetAMIColumn()
+- Those are cached in excel-addin/src/AMI_Optix_DataReader.bas (m_DataSheet, m_AMICol)
+- FindDataSheet() currently prefers ActiveSheet first — this can cause wrong targeting after UI interactions
+
+### 2) Ribbon dropdown currently activates sheets + shows MsgBox
+- Ribbon_SelectRentRoll(...) in excel-addin/src/AMI_Optix_Ribbon.bas uses .Activate and MsgBox
+- Avoid doing this in dropdown callbacks; it can cause context drift and ribbon focus issues
+
+### 3) Utilities already support variants in the UI + payload
+- excel-addin/forms/frmUtilities.frm includes variant codes
+- excel-addin/src/AMI_Optix_API.bas BuildAPIPayload sends electricity/cooking/heat/hot_water
+- “only 4 utilities” symptom is likely display/mapping, not capture
+
+---
+
+## Ledger Template (create if missing)
+(If docs/CODEX_LEDGER.md does not exist, create it using the template in this section.)
+
+# CODEX LEDGER
+
+## Repo + Base Branch
+- Repo: martin10101/nyc-ami-calculator
+- Base branch: perf/api-optimize-speed-2026-02-05
+
+## Render (optional but recommended)
+- Service name:
+- Environment:
+- Service ID: srv-d37n6her433s73et1bp0
+- Auto-deploy setting (On Commit / After CI / Off): OFF
+- Deploy hook URL: [REDACTED]
+
+## Fix Queue
+- [ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+- [ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+- [ ] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+- [ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+- [ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+- [ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+## Work Log
+### YYYY-MM-DD Fix-XX <title>
+- Repo:
+- Base branch:
+- Work branch:
+- Commit:
+- PR:
+- Files changed:
+- Summary:
+- Tests run + results:
+- Render deploy: (manual; ready commit SHA recorded)
+- Notes / risks:
+- Next:

--- a/CODEX.md
+++ b/CODEX.md
@@ -6,7 +6,7 @@ You are working in an existing production repository. Your job is to implement s
 - Repo: martin10101/nyc-ami-calculator
 - Base branch for all fixes: perf/api-optimize-speed-2026-02-05
 
-“Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
+- Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
 
 ## Golden Rules
 1) One fix per iteration. Do not combine fixes.

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -78,7 +78,7 @@
 
 \- Work branch: fix/01-datareader-stability
 
-\- Commit: 875b126ef2a42a9f54a921098897b9cc0a80eb6e
+\- Commit: e370726c9d1b8c7b8627cbb2cb59cdf72783103e
 
 \- PR: \#8 https://github.com/martin10101/nyc-ami-calculator/pull/8
 
@@ -98,13 +98,13 @@
 
 \- Summary:
 
-&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless itâ€™s a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
+&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless it's a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
 
 &nbsp; - Ribbon: rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; DebugLog).
 
 \- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
 
-\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = 875b126ef2a42a9f54a921098897b9cc0a80eb6e
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e370726c9d1b8c7b8627cbb2cb59cdf72783103e
 
 \- Notes / risks:
 

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -26,7 +26,7 @@
 
 \## Fix Queue
 
-\- \[ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+\- \[x] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
 
 \- \[ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
 
@@ -67,6 +67,50 @@
 &nbsp; - Auto-deploy is OFF; deployments are manual from Render dashboard. Record the “ready-to-deploy” commit SHA in the ledger.
 
 \- Next: Fix-01
+
+
+
+\### 2026-02-17 Fix-01 DataReader stability + remove ribbon sheet activation
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01-datareader-stability
+
+\- Commit: 875b126ef2a42a9f54a921098897b9cc0a80eb6e
+
+\- PR: \#8 https://github.com/martin10101/nyc-ami-calculator/pull/8
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01\_DataReader\_stability.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_DataReader.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+\- Summary:
+
+&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless itâ€™s a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
+
+&nbsp; - Ribbon: rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; DebugLog).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = 875b126ef2a42a9f54a921098897b9cc0a80eb6e
+
+\- Notes / risks:
+
+&nbsp; - Workbooks with multiple unit-like tables may resolve to the first matching template-named sheet when the active sheet is not a known program sheet.
+
+\- Next: Fix-04
 
 
 

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -1,0 +1,72 @@
+\# CODEX LEDGER
+
+
+
+\## Repo + Base Branch
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+
+
+\## Render (fill once, keep updated)
+
+\- Service name:
+
+\- Environment:
+
+\- Service ID: srv-d37n6her433s73et1bp0
+
+\- Auto-deploy setting (On Commit / After CI / Off): OFF
+
+\- Deploy hook URL: \[REDACTED]
+
+
+
+\## Fix Queue
+
+\- \[ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+
+\- \[ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+
+\- \[ ] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- \[ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- \[ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+
+\- \[ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+
+
+\## Work Log
+
+\### 2026-02-17 Bootstrap
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: n/a
+
+\- Commit: n/a
+
+\- PR: n/a
+
+\- Files changed: CODEX.md, docs/CODEX\_LEDGER.md
+
+\- Summary: Added persistent operating protocol + ledger so Codex can resume work reliably across sessions and track repo/branch/PR and Render deploy readiness.
+
+\- Tests run + results: n/a
+
+\- Render deploy: n/a
+
+\- Notes / risks:
+
+&nbsp; - Auto-deploy is OFF; deployments are manual from Render dashboard. Record the “ready-to-deploy” commit SHA in the ledger.
+
+\- Next: Fix-01
+
+
+

--- a/docs/FIX_REQUIREMENTS.md
+++ b/docs/FIX_REQUIREMENTS.md
@@ -1,0 +1,280 @@
+\# FIX REQUIREMENTS — NYC AMI Calculator
+
+
+
+Base branch: perf/api-optimize-speed-2026-02-05  
+
+Repo: martin10101/nyc-ami-calculator
+
+
+
+This document defines the expected behavior for each fix.  
+
+Codex must not reinterpret these requirements.
+
+
+
+---
+
+
+
+\## Fix-01 — DataReader stability + remove ribbon sheet activation
+
+\### Problem
+
+Scenario application and other actions sometimes write to the wrong sheet/column after UI interactions because DataReader binds to ActiveSheet and ribbon callbacks activate sheets.
+
+
+
+\### Requirements
+
+\- DataReader must locate MIH/UAP target sheet and AMI column using stable anchors.
+
+\- FindDataSheet must NOT prefer ActiveSheet unless it is explicitly validated to be the MIH/UAP data sheet.
+
+\- Ribbon dropdown callbacks must NOT `.Activate` worksheets and must not use modal MsgBoxes for normal selection.
+
+\- Scenario apply must work even after any manual clears / switching sheets / using dropdowns.
+
+
+
+\### Must NOT change
+
+\- Excel sheet structure or headers.
+
+\- Solver logic.
+
+\- Scenario grid layout.
+
+
+
+\### Test (manual)
+
+\- Apply scenario #2 repeatedly while switching sheets; AMI writes always land in correct column.
+
+\- After using rent roll dropdown, apply scenario; still correct.
+
+
+
+---
+
+
+
+\## Fix-04 — Ribbon stays active (no collapsing)
+
+\### Problem
+
+AMI ribbon tab collapses/disappears after interacting with worksheet, forcing user to click AMI tab again.
+
+
+
+\### Requirements
+
+\- Selecting AMI ribbon tab should behave like normal Excel tabs: it stays active while user works.
+
+\- Dropdown selection and button clicks must not cause the tab to collapse.
+
+\- Must work consistently for all ribbon buttons (MIH + UAP).
+
+
+
+\### Must NOT change
+
+\- Any calculations.
+
+\- Any scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Open AMI tab → click a control → click worksheet cells → AMI tab remains selected.
+
+\- Repeat with dropdown controls and MIH/UAP buttons.
+
+
+
+---
+
+
+
+\## Fix-03 — Rent Roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\### Requirements
+
+\- Add ribbon year selector: 2022, 2023, 2024, 2025, 2026 (default 2025).
+
+\- Add a “Manage Rent Roll Years…” UI (form preferred) to upload/replace year files.
+
+\- Uploaded year files must persist locally (suggested: %APPDATA%\\\\AMI\_Optix\\\\RentRollYears\\\\<year>\\\\).
+
+\- Upload action should also transfer the file once to the API for storage (exact server storage mechanism can be decided, but client must not need to send files manually outside Excel).
+
+\- Selected year must override any year implied inside the active workbook’s rent roll page.
+
+\- If workbook “declared year” != selected year, show warning (OK to continue; not blocking).
+
+\- Every MIH/UAP action that uses rent roll/utilities must use the selected year.
+
+
+
+\### Must NOT change
+
+\- Scenario grid structure.
+
+\- Solver logic (except reading different year data).
+
+\- Existing rent roll math except to swap source year data.
+
+
+
+\### Test (manual)
+
+\- Upload 2022 and 2024.
+
+\- Select 2022 → run calc → confirm it uses 2022 tables.
+
+\- Workbook declares 2025 but dropdown is 2022 → warning appears; OK continues.
+
+
+
+---
+
+
+
+\## Fix-01b — Utilities variant breakdown (top-of-sheet; do not collapse)
+
+\### Problem
+
+Utilities are displayed too generically; the sheet should show which specific variants are used.
+
+
+
+\### Requirements
+
+\- Do NOT alter scenario grid structure or per-scenario columns.
+
+\- Add a top-of-sheet utility breakdown block that shows selected variants (exact names/labels as in rent roll guidelines).
+
+\- Ensure rent roll net rent uses the correct total utility allowance based on selected variants.
+
+\- Utilities are already variant-aware in the UI + payload (electricity/cooking/heat/hot\_water). Ensure display and mapping do not collapse variants incorrectly.
+
+
+
+\### Must NOT change
+
+\- Existing payload keys unless confirmed needed.
+
+\- Scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Pick a non-default heat/hot water variant → run → top-of-sheet shows exact variant and allowance matches.
+
+
+
+---
+
+
+
+\## Fix-02 — Solver dedupe identical outcomes + placement tie-break (Python)
+
+\### Problem
+
+Solver returns “duplicate-looking” scenarios that are outcome-identical but differ only by unit swaps.
+
+
+
+\### Requirements
+
+\- Only dedupe when outcomes are truly identical:
+
+&nbsp; - same AMI band mix
+
+&nbsp; - same rent outcome metrics used for client results
+
+&nbsp; - same relevant mix/sqft outcome if part of outputs
+
+\- Keep only one scenario per equivalence group.
+
+\- Choose the kept scenario using placement tie-break:
+
+&nbsp; - 40% units prefer lower floors
+
+&nbsp; - higher AMI / higher paying units prefer higher floors
+
+\- Must be surgical: do not change solver’s main scoring/constraints; apply as post-processing right before returning results.
+
+
+
+\### Test (manual or unit test)
+
+\- Two identical-outcome scenarios differing only by floor swap → only one returned, preferred placement chosen.
+
+\- Two scenarios with same AMI mix but different rent totals → BOTH remain.
+
+
+
+---
+
+
+
+\## Fix-05 — Manual working-copy always-on + 2-way sync (MIH/UAP + rent roll + year)
+
+\### Goal
+
+Remove the manual scenario on/off toggle completely and make the “manual scenario” the always-present editable working copy.
+
+
+
+\### Requirements
+
+\- There is always an editable Manual Working Copy.
+
+\- Stored solver scenarios (1..N) remain immutable.
+
+\- Selecting scenario #k copies it into Manual Working Copy and applies it to MIH/UAP, but does not change scenario #k snapshot.
+
+\- Edits to Manual Working Copy:
+
+&nbsp; - are allowed even if violating rules (warn but allow override)
+
+&nbsp; - immediately update MIH/UAP AMI column at matching unit
+
+&nbsp; - immediately update rent roll calculations (including using selected rent roll YEAR)
+
+\- Edits to MIH/UAP AMI column:
+
+&nbsp; - immediately update Manual Working Copy
+
+&nbsp; - update rent roll calculations
+
+\- Must include re-entrancy guard to prevent infinite change-event loops.
+
+
+
+\### Must NOT change
+
+\- Scenario snapshots for 1..N.
+
+\- Solver logic.
+
+\- Scenario grid structure.
+
+
+
+\### Test (manual)
+
+\- Select scenario #2 → manual reflects it; scenario #2 snapshot unchanged.
+
+\- Edit manual unit AMI → MIH/UAP updates instantly; rent roll updates.
+
+\- Edit MIH/UAP AMI cell → manual updates; rent roll updates.
+
+\- Repeat after switching sheets and switching selected rent roll year.
+
+
+

--- a/docs/TASKCARD_Fix-01_DataReader_stability.md
+++ b/docs/TASKCARD_Fix-01_DataReader_stability.md
@@ -1,0 +1,48 @@
+# Task Card — Fix-01 DataReader stability + remove ribbon sheet activation
+
+## Goal
+- Prevent `ReadUnitData()` from selecting the wrong worksheet after UI interactions change `ActiveSheet`.
+- Remove rent roll dropdown side effects that activate worksheets (to avoid context drift that can lead to wrong sheet/AMI-column caching).
+
+## Success Criteria
+- Running the solver from the ribbon reads unit data from the intended program sheet even if the user is currently on non-data tabs (e.g., “AMI Scenarios” / diagnostics / other sheets).
+- `GetDataSheet()` and `GetAMIColumn()` remain consistent for subsequent “apply scenario” operations.
+- Selecting a rent roll from the ribbon dropdown does **not** activate/switch the current worksheet.
+
+## Files to Change
+- `excel-addin/src/AMI_Optix_DataReader.bas`
+- `excel-addin/src/AMI_Optix_Ribbon.bas`
+- `docs/CODEX_LEDGER.md` (work log update)
+
+## Functions / Entrypoints
+- `FindDataSheet()` in `AMI_Optix_DataReader.bas`
+- `Ribbon_SelectRentRoll(...)` in `AMI_Optix_Ribbon.bas`
+
+## Proposed Patch (logic-level)
+1) **DataReader sheet selection guardrails**
+   - Keep supporting “active sheet” reads when the active sheet is a known program sheet name (e.g., UAP/MIH/RentRoll variants).
+   - When `ActiveSheet` is *not* a known program sheet, prefer workbook sheets with known template names (UAP/MIH/RentRoll/Project Worksheet/etc) before falling back to arbitrary sheets.
+   - Expand the preferred-name list to include MIH + common Rent Roll variants so MIH flows remain stable without depending on incidental sheet activation order.
+
+2) **Ribbon rent roll dropdown**
+   - Update selection state (`m_SelectedRentRoll`) only.
+   - Remove `Worksheet.Activate` from `Ribbon_SelectRentRoll` and avoid modal UI (no `MsgBox`) for normal selection.
+
+## Risk Pre-mortem
+- **Risk:** Workbooks with multiple “unit-table-looking” sheets may now resolve differently (preferring template-named sheets over a custom active sheet).
+  - **Mitigation:** Keep a fallback path that uses `ActiveSheet` only when no template-named sheet matches; keep the full-workbook scan as the last resort.
+- **Risk:** MIH workbooks where the data sheet name deviates from expected template names could still be ambiguous.
+  - **Mitigation:** Ensure fallback scan still finds a sheet with headers; avoid excluding user sheets beyond known AMI Optix output sheets.
+
+## Test Plan
+- Manual (Excel):
+  1. Open a workbook that includes “UAP” (and/or “MIH”/“RentRoll”) plus the “AMI Scenarios” sheet.
+  2. Activate “AMI Scenarios”, then click **AMI Optix → Run Solver**.
+     - Expected: Units are read from the program sheet (UAP/MIH), and the solver completes normally.
+  3. Select a rent roll in the dropdown.
+     - Expected: The active sheet does not change.
+  4. Apply a scenario from “AMI Scenarios”.
+     - Expected: AMI values write back to the correct data sheet column (no “wrong tab” writes).
+
+## Rollback Plan
+- Revert the fix commit (single-commit revert) and redeploy the prior SHA if needed.

--- a/excel-addin/src/AMI_Optix_DataReader.bas
+++ b/excel-addin/src/AMI_Optix_DataReader.bas
@@ -146,8 +146,7 @@ End Function
 Private Function IsPreferredSheetName(sheetName As String) As Boolean
     Dim s As String
     s = UCase$(Trim$(sheetName))
-    IsPreferredSheetName = (s = "UAP" Or s = "MIH" Or s = "PROJECT WORKSHEET" Or s = "RENTROLL" Or s = "RENT ROLL" Or _
-                            s = "UNITS" Or s = "UNIT SCHEDULE" Or s = "SHEET1" Or s = "DATA")
+    IsPreferredSheetName = (s = "UAP" Or s = "MIH" Or s = "PROJECT WORKSHEET" Or s = "RENTROLL" Or s = "RENT ROLL")
 End Function
 
 Private Function HasUnitDataHeaders(ws As Worksheet) As Boolean

--- a/excel-addin/src/AMI_Optix_DataReader.bas
+++ b/excel-addin/src/AMI_Optix_DataReader.bas
@@ -32,7 +32,7 @@ Public Function ReadUnitData() As Collection
 
     On Error GoTo ErrorHandler
 
-    ' Try to find data in active sheet first, then search all sheets
+    ' Find a stable data sheet (prefer known template sheet names over incidental ActiveSheet)
     Set ws = FindDataSheet()
 
     If ws Is Nothing Then
@@ -86,15 +86,29 @@ Private Function FindDataSheet() As Worksheet
     Dim ws As Worksheet
     Dim preferredNames As Variant
     Dim i As Long
+    Dim activeWs As Worksheet
 
-    ' First try active sheet
-    If HasUnitDataHeaders(ActiveSheet) Then
-        Set FindDataSheet = ActiveSheet
+    If ActiveWorkbook Is Nothing Then
+        Set FindDataSheet = Nothing
         Exit Function
     End If
 
-    ' Try preferred sheet names
-    preferredNames = Array("UAP", "PROJECT WORKSHEET", "RentRoll", "Units", "Sheet1", "Data")
+    ' Only treat the active sheet as authoritative if it's a known template/program sheet.
+    Set activeWs = Nothing
+    On Error Resume Next
+    Set activeWs = ActiveSheet
+    On Error GoTo 0
+
+    preferredNames = Array("UAP", "MIH", "PROJECT WORKSHEET", "RentRoll", "Rent Roll", "Units", "Unit Schedule", "Sheet1", "Data")
+
+    If Not activeWs Is Nothing Then
+        If IsPreferredSheetName(activeWs.Name) Then
+            If HasUnitDataHeaders(activeWs) Then
+                Set FindDataSheet = activeWs
+                Exit Function
+            End If
+        End If
+    End If
 
     For i = LBound(preferredNames) To UBound(preferredNames)
         On Error Resume Next
@@ -110,6 +124,14 @@ Private Function FindDataSheet() As Worksheet
         Set ws = Nothing
     Next i
 
+    ' Fallback: if the active sheet has headers but isn't a template name, allow it.
+    If Not activeWs Is Nothing Then
+        If HasUnitDataHeaders(activeWs) Then
+            Set FindDataSheet = activeWs
+            Exit Function
+        End If
+    End If
+
     ' Search all sheets
     For Each ws In ActiveWorkbook.Worksheets
         If HasUnitDataHeaders(ws) Then
@@ -119,6 +141,13 @@ Private Function FindDataSheet() As Worksheet
     Next ws
 
     Set FindDataSheet = Nothing
+End Function
+
+Private Function IsPreferredSheetName(sheetName As String) As Boolean
+    Dim s As String
+    s = UCase$(Trim$(sheetName))
+    IsPreferredSheetName = (s = "UAP" Or s = "MIH" Or s = "PROJECT WORKSHEET" Or s = "RENTROLL" Or s = "RENT ROLL" Or _
+                            s = "UNITS" Or s = "UNIT SCHEDULE" Or s = "SHEET1" Or s = "DATA")
 End Function
 
 Private Function HasUnitDataHeaders(ws As Worksheet) As Boolean

--- a/excel-addin/src/AMI_Optix_Ribbon.bas
+++ b/excel-addin/src/AMI_Optix_Ribbon.bas
@@ -661,13 +661,7 @@ Public Sub Ribbon_SelectRentRoll(control As IRibbonControl, id As String, index 
     ' Called when user selects a rent roll from dropdown
     If index >= 0 And index < m_RentRollCount Then
         m_SelectedRentRoll = m_RentRollSheets(index)
-
-        ' Activate the selected sheet
-        On Error Resume Next
-        ActiveWorkbook.Worksheets(m_SelectedRentRoll).Activate
-        On Error GoTo 0
-
-        MsgBox "Selected rent roll: " & m_SelectedRentRoll, vbInformation, "AMI Optix"
+        DebugLog "Ribbon_SelectRentRoll: selected=" & m_SelectedRentRoll, True
     End If
 End Sub
 


### PR DESCRIPTION
## Summary\n- Stabilize DataReader sheet selection: prefer known template/program sheet names over incidental ActiveSheet.\n- Rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; logs via DebugLog).\n\n## Tests\n- python -m pytest -q (51 passed)\n\n## Manual QA\n- See docs/TASKCARD_Fix-01_DataReader_stability.md