### PR TITLE
Fix-03: Rent roll YEAR selector + manage uploads

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,147 @@
+# CODEX OPERATING PROTOCOL — NYC AMI Calculator
+
+You are working in an existing production repository. Your job is to implement small, isolated fixes without breaking established logic.
+
+## Repo + Base Branch (must be explicit)
+- Repo: martin10101/nyc-ami-calculator
+- Base branch for all fixes: perf/api-optimize-speed-2026-02-05
+
+- Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
+
+## Golden Rules
+1) One fix per iteration. Do not combine fixes.
+2) Minimal diff. No refactors, renames, formatting sweeps, or dependency changes unless explicitly required.
+3) Preserve interfaces and Excel sheet structure unless the fix explicitly changes them.
+4) Do not change solver scoring/constraints unless the fix explicitly targets solver behavior.
+5) If you think you must touch >3 files, STOP and ask for approval.
+6) Never rely on ActiveSheet to locate MIH/UAP targets unless explicitly verified safe.
+
+## Required Workflow (every session)
+### Step 0 — Read the Ledger (required)
+Open docs/CODEX_LEDGER.md and identify:
+- the next unchecked fix in the queue,
+- the last completed fix,
+- any open risks or follow-ups.
+
+### Step 1 — Create a Branch
+Create a branch from the base branch:
+- fix/<ID>-<short-slug>
+
+### Step 2 — Produce a Task Card (before coding)
+Write a Task Card that includes:
+- Goal (2–4 bullets)
+- Success Criteria
+- Files to change (exact paths)
+- Functions/entrypoints to change
+- Proposed patch (logic-level description)
+- Risk pre-mortem (how this could break things + mitigations)
+- Test plan (exact steps)
+- Rollback plan
+
+Do not code until the Task Card is written.
+
+### Step 3 — Implement
+- Only implement what was proposed in the Task Card.
+- Keep changes localized.
+- Add/adjust tests only when lightweight and aligned with repo.
+
+### Step 4 — Verify
+- Run tests if possible.
+- If you cannot run tests, provide exact manual test steps and expected outputs.
+
+### Step 5 — GitHub Push + PR (required)
+After committing:
+1) Push the branch to origin.
+2) Open a draft PR targeting the base branch (perf/api-optimize-speed-2026-02-05).
+3) Put the Fix ID in the PR title (e.g., "Fix-04: Ribbon stays active").
+
+### Step 6 — Update Ledger (required)
+Update docs/CODEX_LEDGER.md with:
+- Repo + base branch
+- Work branch + commit SHA
+- PR number/link (or "no PR")
+- Files changed
+- Summary of changes
+- Tests run + results
+- Remaining notes/risks
+- Render deploy status (see below)
+Then STOP. Do not start the next fix.
+
+---
+
+## Render Deployment Rule (GitHub-backed service)
+We want deterministic deployments tied to a commit SHA, not branch-hopping.
+
+### Current setting (do not change)
+- Auto-deploy: OFF
+- Service ID: srv-d37n6her433s73et1bp0
+
+### Behavior required from Codex
+- Do NOT trigger deployments automatically.
+- Only record the ready-to-deploy commit SHA in docs/CODEX_LEDGER.md and tell the user which commit/PR to deploy.
+
+Preferred method (manual by user):
+- User deploys from Render dashboard when ready.
+Optional method (only if user provides deploy hook secret out-of-band):
+- Trigger deploy via Render deploy hook with `ref=<commit_sha>` (deploy specific commit).
+  - Note: deploying a specific commit may disable auto-deploys until reenabled. (Render docs)
+
+Render MCP note:
+- Render MCP currently does NOT support triggering deploys or modifying existing services (except env vars). Therefore do NOT rely on MCP for branch switching or deploy triggers. (Render docs)
+
+---
+
+## Known repo-specific findings (use these to guide safe fixes)
+### 1) Scenario apply uses cached DataSheet + AMI column
+- ApplyScenarioByKey(...) in excel-addin/src/AMI_Optix_ResultsWriter.bas calls GetDataSheet() and GetAMIColumn()
+- Those are cached in excel-addin/src/AMI_Optix_DataReader.bas (m_DataSheet, m_AMICol)
+- FindDataSheet() currently prefers ActiveSheet first — this can cause wrong targeting after UI interactions
+
+### 2) Ribbon dropdown currently activates sheets + shows MsgBox
+- Ribbon_SelectRentRoll(...) in excel-addin/src/AMI_Optix_Ribbon.bas uses .Activate and MsgBox
+- Avoid doing this in dropdown callbacks; it can cause context drift and ribbon focus issues
+
+### 3) Utilities already support variants in the UI + payload
+- excel-addin/forms/frmUtilities.frm includes variant codes
+- excel-addin/src/AMI_Optix_API.bas BuildAPIPayload sends electricity/cooking/heat/hot_water
+- “only 4 utilities” symptom is likely display/mapping, not capture
+
+---
+
+## Ledger Template (create if missing)
+(If docs/CODEX_LEDGER.md does not exist, create it using the template in this section.)
+
+# CODEX LEDGER
+
+## Repo + Base Branch
+- Repo: martin10101/nyc-ami-calculator
+- Base branch: perf/api-optimize-speed-2026-02-05
+
+## Render (optional but recommended)
+- Service name:
+- Environment:
+- Service ID: srv-d37n6her433s73et1bp0
+- Auto-deploy setting (On Commit / After CI / Off): OFF
+- Deploy hook URL: [REDACTED]
+
+## Fix Queue
+- [ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+- [ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+- [ ] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+- [ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+- [ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+- [ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+## Work Log
+### YYYY-MM-DD Fix-XX <title>
+- Repo:
+- Base branch:
+- Work branch:
+- Commit:
+- PR:
+- Files changed:
+- Summary:
+- Tests run + results:
+- Render deploy: (manual; ready commit SHA recorded)
+- Notes / risks:
+- Next:

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -1,0 +1,210 @@
+\# CODEX LEDGER
+
+
+
+\## Repo + Base Branch
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+
+
+\## Render (fill once, keep updated)
+
+\- Service name:
+
+\- Environment:
+
+\- Service ID: srv-d37n6her433s73et1bp0
+
+\- Auto-deploy setting (On Commit / After CI / Off): OFF
+
+\- Deploy hook URL: \[REDACTED]
+
+
+
+\## Fix Queue
+
+\- \[x] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+
+\- \[x] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+
+\- \[x] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- \[ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- \[ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+
+\- \[ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+
+
+\## Work Log
+
+\### 2026-02-17 Bootstrap
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: n/a
+
+\- Commit: n/a
+
+\- PR: n/a
+
+\- Files changed: CODEX.md, docs/CODEX\_LEDGER.md
+
+\- Summary: Added persistent operating protocol + ledger so Codex can resume work reliably across sessions and track repo/branch/PR and Render deploy readiness.
+
+\- Tests run + results: n/a
+
+\- Render deploy: n/a
+
+\- Notes / risks:
+
+&nbsp; - Auto-deploy is OFF; deployments are manual from Render dashboard. Record the “ready-to-deploy” commit SHA in the ledger.
+
+\- Next: Fix-01
+
+
+
+\### 2026-02-17 Fix-01 DataReader stability + remove ribbon sheet activation
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01-datareader-stability
+
+\- Commit: e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- PR: \#8 https://github.com/martin10101/nyc-ami-calculator/pull/8
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01\_DataReader\_stability.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_DataReader.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+\- Summary:
+
+&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless it's a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
+
+&nbsp; - Ribbon: rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; DebugLog).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- Notes / risks:
+
+&nbsp; - Workbooks with multiple unit-like tables may resolve to the first matching template-named sheet when the active sheet is not a known program sheet.
+
+\- Next: Fix-04
+
+
+
+\### 2026-02-18 Fix-04 Ribbon stays active (no collapsing)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/04-ribbon-stays-active
+
+\- Commit: f6792738125956226d4088d90239eba42cbfc8ff
+
+\- PR: \#9 https://github.com/martin10101/nyc-ami-calculator/pull/9
+
+\- Files changed:
+
+&nbsp; - docs/TASKCARD\_Fix-04\_Ribbon\_stays\_active.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+\- Summary:
+
+&nbsp; - Ribbon XML: add onLoad hook so VBA can capture `IRibbonUI`.
+
+&nbsp; - Ribbon callbacks: best-effort re-activate `tabAMIOptix` after `onAction` handlers so the AMI Optix tab remains selected after actions.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = f6792738125956226d4088d90239eba42cbfc8ff
+
+\- Notes / risks:
+
+&nbsp; - PR \#9 is stacked on PR \#8; merge PR \#8 first to reduce diff.
+
+\- Next: Fix-03
+
+
+
+\### 2026-02-18 Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/03-rent-roll-year-selector
+
+\- Commit: e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- PR: \#10 https://github.com/martin10101/nyc-ami-calculator/pull/10
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-03\_RentRoll\_YEAR\_selector.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_API.bas
+
+\- Summary:
+
+&nbsp; - Ribbon: add **Rent Roll Year** dropdown (2022â€“2026, default 2025) + **Manage Rent Roll Yearsâ€¦** upload/replace action.
+
+&nbsp; - Local persistence: store selected year calculators under `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`.
+
+&nbsp; - API storage: upload selected year calculator to `/api/rent-calculators/upload` and activate via `/api/rent-calculators/activate`.
+
+&nbsp; - Enforcement: API calls (optimize/evaluate/manual\_calculate) ensure the selected year is active before running.
+
+&nbsp; - Warning: best-effort mismatch warning if workbook appears to declare a different year than the selection (OK continues; not blocking).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- Notes / risks:
+
+&nbsp; - Rent calculator activation is server-global; switching years affects other clients using the same API service.
+
+&nbsp; - Declared-year detection is best-effort; some templates may not yield a detectable year (no warning shown).
+
+\- Next: Fix-01b
+
+
+

--- a/docs/FIX_REQUIREMENTS.md
+++ b/docs/FIX_REQUIREMENTS.md
@@ -1,0 +1,280 @@
+\# FIX REQUIREMENTS — NYC AMI Calculator
+
+
+
+Base branch: perf/api-optimize-speed-2026-02-05  
+
+Repo: martin10101/nyc-ami-calculator
+
+
+
+This document defines the expected behavior for each fix.  
+
+Codex must not reinterpret these requirements.
+
+
+
+---
+
+
+
+\## Fix-01 — DataReader stability + remove ribbon sheet activation
+
+\### Problem
+
+Scenario application and other actions sometimes write to the wrong sheet/column after UI interactions because DataReader binds to ActiveSheet and ribbon callbacks activate sheets.
+
+
+
+\### Requirements
+
+\- DataReader must locate MIH/UAP target sheet and AMI column using stable anchors.
+
+\- FindDataSheet must NOT prefer ActiveSheet unless it is explicitly validated to be the MIH/UAP data sheet.
+
+\- Ribbon dropdown callbacks must NOT `.Activate` worksheets and must not use modal MsgBoxes for normal selection.
+
+\- Scenario apply must work even after any manual clears / switching sheets / using dropdowns.
+
+
+
+\### Must NOT change
+
+\- Excel sheet structure or headers.
+
+\- Solver logic.
+
+\- Scenario grid layout.
+
+
+
+\### Test (manual)
+
+\- Apply scenario #2 repeatedly while switching sheets; AMI writes always land in correct column.
+
+\- After using rent roll dropdown, apply scenario; still correct.
+
+
+
+---
+
+
+
+\## Fix-04 — Ribbon stays active (no collapsing)
+
+\### Problem
+
+AMI ribbon tab collapses/disappears after interacting with worksheet, forcing user to click AMI tab again.
+
+
+
+\### Requirements
+
+\- Selecting AMI ribbon tab should behave like normal Excel tabs: it stays active while user works.
+
+\- Dropdown selection and button clicks must not cause the tab to collapse.
+
+\- Must work consistently for all ribbon buttons (MIH + UAP).
+
+
+
+\### Must NOT change
+
+\- Any calculations.
+
+\- Any scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Open AMI tab → click a control → click worksheet cells → AMI tab remains selected.
+
+\- Repeat with dropdown controls and MIH/UAP buttons.
+
+
+
+---
+
+
+
+\## Fix-03 — Rent Roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\### Requirements
+
+\- Add ribbon year selector: 2022, 2023, 2024, 2025, 2026 (default 2025).
+
+\- Add a “Manage Rent Roll Years…” UI (form preferred) to upload/replace year files.
+
+\- Uploaded year files must persist locally (suggested: %APPDATA%\\\\AMI\_Optix\\\\RentRollYears\\\\<year>\\\\).
+
+\- Upload action should also transfer the file once to the API for storage (exact server storage mechanism can be decided, but client must not need to send files manually outside Excel).
+
+\- Selected year must override any year implied inside the active workbook’s rent roll page.
+
+\- If workbook “declared year” != selected year, show warning (OK to continue; not blocking).
+
+\- Every MIH/UAP action that uses rent roll/utilities must use the selected year.
+
+
+
+\### Must NOT change
+
+\- Scenario grid structure.
+
+\- Solver logic (except reading different year data).
+
+\- Existing rent roll math except to swap source year data.
+
+
+
+\### Test (manual)
+
+\- Upload 2022 and 2024.
+
+\- Select 2022 → run calc → confirm it uses 2022 tables.
+
+\- Workbook declares 2025 but dropdown is 2022 → warning appears; OK continues.
+
+
+
+---
+
+
+
+\## Fix-01b — Utilities variant breakdown (top-of-sheet; do not collapse)
+
+\### Problem
+
+Utilities are displayed too generically; the sheet should show which specific variants are used.
+
+
+
+\### Requirements
+
+\- Do NOT alter scenario grid structure or per-scenario columns.
+
+\- Add a top-of-sheet utility breakdown block that shows selected variants (exact names/labels as in rent roll guidelines).
+
+\- Ensure rent roll net rent uses the correct total utility allowance based on selected variants.
+
+\- Utilities are already variant-aware in the UI + payload (electricity/cooking/heat/hot\_water). Ensure display and mapping do not collapse variants incorrectly.
+
+
+
+\### Must NOT change
+
+\- Existing payload keys unless confirmed needed.
+
+\- Scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Pick a non-default heat/hot water variant → run → top-of-sheet shows exact variant and allowance matches.
+
+
+
+---
+
+
+
+\## Fix-02 — Solver dedupe identical outcomes + placement tie-break (Python)
+
+\### Problem
+
+Solver returns “duplicate-looking” scenarios that are outcome-identical but differ only by unit swaps.
+
+
+
+\### Requirements
+
+\- Only dedupe when outcomes are truly identical:
+
+&nbsp; - same AMI band mix
+
+&nbsp; - same rent outcome metrics used for client results
+
+&nbsp; - same relevant mix/sqft outcome if part of outputs
+
+\- Keep only one scenario per equivalence group.
+
+\- Choose the kept scenario using placement tie-break:
+
+&nbsp; - 40% units prefer lower floors
+
+&nbsp; - higher AMI / higher paying units prefer higher floors
+
+\- Must be surgical: do not change solver’s main scoring/constraints; apply as post-processing right before returning results.
+
+
+
+\### Test (manual or unit test)
+
+\- Two identical-outcome scenarios differing only by floor swap → only one returned, preferred placement chosen.
+
+\- Two scenarios with same AMI mix but different rent totals → BOTH remain.
+
+
+
+---
+
+
+
+\## Fix-05 — Manual working-copy always-on + 2-way sync (MIH/UAP + rent roll + year)
+
+\### Goal
+
+Remove the manual scenario on/off toggle completely and make the “manual scenario” the always-present editable working copy.
+
+
+
+\### Requirements
+
+\- There is always an editable Manual Working Copy.
+
+\- Stored solver scenarios (1..N) remain immutable.
+
+\- Selecting scenario #k copies it into Manual Working Copy and applies it to MIH/UAP, but does not change scenario #k snapshot.
+
+\- Edits to Manual Working Copy:
+
+&nbsp; - are allowed even if violating rules (warn but allow override)
+
+&nbsp; - immediately update MIH/UAP AMI column at matching unit
+
+&nbsp; - immediately update rent roll calculations (including using selected rent roll YEAR)
+
+\- Edits to MIH/UAP AMI column:
+
+&nbsp; - immediately update Manual Working Copy
+
+&nbsp; - update rent roll calculations
+
+\- Must include re-entrancy guard to prevent infinite change-event loops.
+
+
+
+\### Must NOT change
+
+\- Scenario snapshots for 1..N.
+
+\- Solver logic.
+
+\- Scenario grid structure.
+
+
+
+\### Test (manual)
+
+\- Select scenario #2 → manual reflects it; scenario #2 snapshot unchanged.
+
+\- Edit manual unit AMI → MIH/UAP updates instantly; rent roll updates.
+
+\- Edit MIH/UAP AMI cell → manual updates; rent roll updates.
+
+\- Repeat after switching sheets and switching selected rent roll year.
+
+
+

--- a/docs/TASKCARD_Fix-03_RentRoll_YEAR_selector.md
+++ b/docs/TASKCARD_Fix-03_RentRoll_YEAR_selector.md
@@ -1,0 +1,80 @@
+# Task Card — Fix-03 Rent Roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+## Goal
+- Add a **Rent Roll Year** selector (2022–2026, default **2025**) in the AMI Optix ribbon.
+- Provide an in-Excel **Manage Rent Roll Years…** action to upload/replace year calculator files.
+- Ensure all MIH/UAP workflows that compute rents/utilities use the **selected year**.
+
+## Acceptance Criteria (from `docs/FIX_REQUIREMENTS.md`)
+- Add ribbon year selector: 2022, 2023, 2024, 2025, 2026 (default 2025).
+- Add a “Manage Rent Roll Years…” UI (form preferred) to upload/replace year files.
+- Uploaded year files must persist locally (suggested: `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`).
+- Upload action should also transfer the file once to the API for storage.
+- Selected year must override any year implied inside the active workbook’s rent roll page.
+- If workbook “declared year” != selected year, show warning (OK to continue; not blocking).
+- Every MIH/UAP action that uses rent roll/utilities must use the selected year.
+
+## Success Criteria
+- User can select a year (defaults to 2025) and the server uses that year’s rent calculator for subsequent optimize/evaluate/manual-calculate calls.
+- “Manage Rent Roll Years…” lets user pick a rent calculator workbook and:
+  - copies it into `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`
+  - uploads it to the API’s rent-calculator storage (overwrite supported)
+  - activates it on the API so computations use that year immediately
+- If the active workbook appears to declare a different year than the selection, a warning is shown and the user can proceed.
+
+## Files to Change
+- `excel-addin/customUI/customUI14.xml`
+- `excel-addin/src/AMI_Optix_Ribbon.bas`
+- `excel-addin/src/AMI_Optix_API.bas`
+- `docs/CODEX_LEDGER.md` (work log update)
+
+## Functions / Entrypoints
+- RibbonX:
+  - Year dropdown callbacks: `Ribbon_GetRentRollYear*`, `Ribbon_SelectRentRollYear`
+  - Manage button: `Ribbon_ManageRentRollYears`
+- API calls (Excel → Render):
+  - `POST /api/rent-calculators/upload` (multipart form-data)
+  - `POST /api/rent-calculators/activate` (JSON)
+  - `CallOptimizeAPI`, `CallEvaluateAPI`, `CallManualCalculateAPI` (ensure selected year activated)
+
+## Proposed Patch (logic-level)
+1) **Ribbon UI**
+   - Add a “Rent Roll Year” dropdown with fixed options 2022–2026 (default 2025).
+   - Add a “Manage Rent Roll Years…” button in the Rent Roll group.
+
+2) **Local persistence**
+   - Store uploaded calculator files under `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`.
+   - Store selected year (and remote filename used) in the registry via `SaveSetting` so it survives Excel restarts.
+
+3) **API storage + activation**
+   - On “Manage…” upload: POST the chosen file to `/api/rent-calculators/upload` (with `overwrite=true`), then activate it.
+   - On year selection change: activate the matching year calculator on the API (or activate default for 2025).
+   - Before any optimize/evaluate/manual-calculate request: ensure the selected year is activated (so Live Sync / worksheet-driven calls also use the selected year).
+
+4) **Mismatch warning**
+   - Best-effort detect a “declared year” (from workbook name / rent roll sheet name / top-of-sheet scan).
+   - If it differs from selected year, show a warning that does not block continuing.
+
+## Risk Pre-mortem
+- **Risk:** API rent calculator activation is server-global; switching years affects other concurrent users.
+  - **Mitigation:** Keep behavior explicit (only switches on user year selection / Manage upload); document as known limitation.
+- **Risk:** Declared-year detection may miss or mis-detect in some workbooks.
+  - **Mitigation:** Best-effort only; warning shown only when a clear year is detected.
+- **Risk:** Multipart upload code could fail on large files or locked paths.
+  - **Mitigation:** Clear error messaging; local copy step first; use conservative timeouts.
+
+## Test Plan
+- Manual (Excel):
+  1. Open a workbook with AMI Optix add-in installed.
+  2. Use **Manage Rent Roll Years…**:
+     - Select year **2022** and upload a valid 2022 calculator workbook.
+     - Repeat for **2024**.
+  3. Select **2022** in the year dropdown.
+  4. Run **Run UAP** (or **Manual Calculate**) and verify outputs reflect 2022 rent tables.
+  5. With a workbook that appears to declare **2025**, select **2022** → warning appears; clicking OK continues.
+
+- Automated (repo sanity):
+  - `python -m pytest -q`
+
+## Rollback Plan
+- Revert the fix commit(s) and rebuild the `.xlam` with prior ribbon/module versions.

--- a/excel-addin/customUI/customUI14.xml
+++ b/excel-addin/customUI/customUI14.xml
@@ -24,6 +24,21 @@
                   supertip="View and apply different optimization scenarios from the last solver run."/>
         </group>
         <group id="grpRentRoll" label="Rent Roll">
+          <dropDown id="ddRentRollYear"
+                    label="Rent Roll Year"
+                    showLabel="true"
+                    onAction="Ribbon_SelectRentRollYear"
+                    getItemCount="Ribbon_GetRentRollYearCount"
+                    getItemLabel="Ribbon_GetRentRollYearLabel"
+                    getItemID="Ribbon_GetRentRollYearID"
+                    getSelectedItemIndex="Ribbon_GetRentRollYearSelectedIndex"
+                    supertip="Select which rent calculator year to use for MIH/UAP calculations (default 2025)."/>
+          <button id="btnManageRentRollYears"
+                  label="Manage Rent Roll Years..."
+                  size="normal"
+                  imageMso="FileOpen"
+                  onAction="Ribbon_ManageRentRollYears"
+                  supertip="Upload/replace the rent calculator for the selected year and activate it on the API."/>
           <dropDown id="ddRentRoll"
                     label="Select Rent Roll"
                     showLabel="true"

--- a/excel-addin/src/AMI_Optix_API.bas
+++ b/excel-addin/src/AMI_Optix_API.bas
@@ -8,8 +8,283 @@ Attribute VB_Name = "AMI_Optix_API"
 Option Explicit
 
 '-------------------------------------------------------------------------------
+' RENT CALCULATOR YEAR (Fix-03)
+'-------------------------------------------------------------------------------
+
+Private Const AMI_OPTIX_REGISTRY_PATH As String = "AMI_Optix"
+Private Const RENTROLL_YEAR_REG_SECTION As String = "RentRollYears"
+Private Const RENTROLL_YEAR_REG_KEY_SELECTED As String = "SelectedYear"
+
+Private Const RENTROLL_YEAR_MIN As Long = 2022
+Private Const RENTROLL_YEAR_MAX As Long = 2026
+Private Const RENTROLL_YEAR_DEFAULT As Long = 2025
+
+Private Const RENT_CALC_REMOTE_PREFIX As String = "AMI_Optix_Rent_Calculator_"
+Private Const RENT_CALC_REMOTE_SUFFIX As String = ".xlsx"
+Private Const RENT_CALC_REMOTE_DEFAULT_NAME As String = "default"
+
+Private m_LastActivatedRentCalcName As String
+Private m_LastActivationWarnedName As String
+Private m_DefaultYearOverrideUnavailable As Boolean
+
+'-------------------------------------------------------------------------------
 ' API CALL
 '-------------------------------------------------------------------------------
+
+Public Function EnsureSelectedRentRollYearActive(Optional showErrors As Boolean = False) As Boolean
+    ' Ensures the API is using the rent calculator matching the user's selected Rent Roll Year.
+    Dim year As Long
+    year = GetSelectedRentRollYearSetting()
+    EnsureSelectedRentRollYearActive = EnsureRentCalculatorYearActive(year, showErrors)
+End Function
+
+Public Function ActivateRentCalculatorByName(name As String, Optional showErrors As Boolean = True) As Boolean
+    ActivateRentCalculatorByName = ActivateRentCalculatorByNameInternal(CStr(name), showErrors)
+
+    If ActivateRentCalculatorByName Then
+        m_LastActivatedRentCalcName = CStr(name)
+        m_LastActivationWarnedName = ""
+    End If
+End Function
+
+Public Function UploadRentCalculatorFile( _
+    localFilePath As String, _
+    remoteFileName As String, _
+    Optional overwrite As Boolean = True, _
+    Optional showErrors As Boolean = True _
+) As Boolean
+    ' Uploads a rent calculator workbook to the API storage (multipart/form-data).
+    On Error GoTo Fail
+
+    If Trim$(localFilePath) = "" Or Dir(localFilePath) = "" Then
+        If showErrors Then
+            MsgBox "File not found:" & vbCrLf & localFilePath, vbExclamation, "AMI Optix"
+        End If
+        Exit Function
+    End If
+
+    Dim boundary As String
+    boundary = MakeMultipartBoundary()
+
+    Dim body As Variant
+    body = BuildRentCalculatorUploadBodyBytes(localFilePath, remoteFileName, overwrite, boundary)
+
+    Dim http As Object
+    Dim url As String
+    Dim apiKey As String
+
+    url = API_BASE_URL & "/api/rent-calculators/upload"
+    apiKey = GetAPIKey()
+
+    Set http = CreateObject("MSXML2.ServerXMLHTTP.6.0")
+    http.setTimeouts 5000, 30000, 30000, 240000
+
+    http.Open "POST", url, False
+    http.setRequestHeader "Content-Type", "multipart/form-data; boundary=" & boundary
+    http.setRequestHeader "Accept", "application/json"
+    If Len(apiKey) > 0 Then
+        http.setRequestHeader "X-API-Key", apiKey
+    End If
+
+    http.send body
+
+    If http.Status = 200 Then
+        UploadRentCalculatorFile = True
+    Else
+        If showErrors Then
+            Dim msg As String
+            msg = "Rent calculator upload failed." & vbCrLf & _
+                  "Status: " & http.Status & " - " & http.statusText
+            If Len(http.responseText) > 0 Then msg = msg & vbCrLf & vbCrLf & http.responseText
+            MsgBox msg, vbExclamation, "AMI Optix"
+        End If
+        UploadRentCalculatorFile = False
+    End If
+    Exit Function
+
+Fail:
+    If showErrors Then
+        MsgBox "Rent calculator upload failed: " & Err.Description, vbExclamation, "AMI Optix"
+    End If
+    UploadRentCalculatorFile = False
+End Function
+
+Private Function GetSelectedRentRollYearSetting() As Long
+    Dim raw As String
+    raw = GetSetting(AMI_OPTIX_REGISTRY_PATH, RENTROLL_YEAR_REG_SECTION, RENTROLL_YEAR_REG_KEY_SELECTED, CStr(RENTROLL_YEAR_DEFAULT))
+
+    Dim y As Long
+    y = RENTROLL_YEAR_DEFAULT
+    On Error Resume Next
+    y = CLng(raw)
+    On Error GoTo 0
+
+    If y < RENTROLL_YEAR_MIN Or y > RENTROLL_YEAR_MAX Then y = RENTROLL_YEAR_DEFAULT
+    GetSelectedRentRollYearSetting = y
+End Function
+
+Private Function EnsureRentCalculatorYearActive(year As Long, showErrors As Boolean) As Boolean
+    Dim targetName As String
+
+    If year = RENTROLL_YEAR_DEFAULT Then
+        ' Default year normally uses the built-in default calculator.
+        ' If the user uploaded a 2025 override (same naming convention), prefer it when available.
+        Dim overrideName As String
+        overrideName = RentCalculatorRemoteNameForYear(year)
+
+        If m_LastActivatedRentCalcName = overrideName Then
+            EnsureRentCalculatorYearActive = True
+            Exit Function
+        End If
+
+        If Not m_DefaultYearOverrideUnavailable Then
+            If ActivateRentCalculatorByNameInternal(overrideName, False) Then
+                m_LastActivatedRentCalcName = overrideName
+                m_LastActivationWarnedName = ""
+                EnsureRentCalculatorYearActive = True
+                Exit Function
+            End If
+            m_DefaultYearOverrideUnavailable = True
+        End If
+
+        targetName = RENT_CALC_REMOTE_DEFAULT_NAME
+    Else
+        targetName = RentCalculatorRemoteNameForYear(year)
+    End If
+
+    If targetName = "" Then
+        EnsureRentCalculatorYearActive = True
+        Exit Function
+    End If
+
+    If m_LastActivatedRentCalcName = targetName Then
+        EnsureRentCalculatorYearActive = True
+        Exit Function
+    End If
+
+    Dim allowUI As Boolean
+    allowUI = showErrors
+    If showErrors Then
+        If m_LastActivationWarnedName = targetName Then allowUI = False
+    End If
+
+    If ActivateRentCalculatorByNameInternal(targetName, allowUI) Then
+        m_LastActivatedRentCalcName = targetName
+        m_LastActivationWarnedName = ""
+        EnsureRentCalculatorYearActive = True
+        Exit Function
+    End If
+
+    If showErrors And m_LastActivationWarnedName <> targetName Then
+        m_LastActivationWarnedName = targetName
+    End If
+
+    EnsureRentCalculatorYearActive = False
+End Function
+
+Private Function RentCalculatorRemoteNameForYear(year As Long) As String
+    RentCalculatorRemoteNameForYear = RENT_CALC_REMOTE_PREFIX & CStr(year) & RENT_CALC_REMOTE_SUFFIX
+End Function
+
+Private Function ActivateRentCalculatorByNameInternal(name As String, showErrors As Boolean) As Boolean
+    On Error GoTo Fail
+
+    Dim http As Object
+    Dim url As String
+    Dim apiKey As String
+    Dim payload As String
+
+    url = API_BASE_URL & "/api/rent-calculators/activate"
+    apiKey = GetAPIKey()
+    payload = "{""name"": """ & EscapeJSON(CStr(name)) & """}"
+
+    Set http = CreateObject("MSXML2.ServerXMLHTTP.6.0")
+    http.setTimeouts 5000, 30000, 30000, 60000
+
+    http.Open "POST", url, False
+    http.setRequestHeader "Content-Type", "application/json"
+    http.setRequestHeader "Accept", "application/json"
+    If Len(apiKey) > 0 Then
+        http.setRequestHeader "X-API-Key", apiKey
+    End If
+
+    http.send payload
+
+    If http.Status = 200 Then
+        ActivateRentCalculatorByNameInternal = True
+    Else
+        If showErrors Then
+            Dim msg As String
+            msg = "Could not activate rent calculator." & vbCrLf & _
+                  "Status: " & http.Status & " - " & http.statusText & vbCrLf & _
+                  "Name: " & CStr(name)
+            If Len(http.responseText) > 0 Then msg = msg & vbCrLf & vbCrLf & http.responseText
+            MsgBox msg, vbExclamation, "AMI Optix"
+        End If
+        ActivateRentCalculatorByNameInternal = False
+    End If
+    Exit Function
+
+Fail:
+    If showErrors Then
+        MsgBox "Could not activate rent calculator: " & Err.Description, vbExclamation, "AMI Optix"
+    End If
+    ActivateRentCalculatorByNameInternal = False
+End Function
+
+Private Function MakeMultipartBoundary() As String
+    Randomize
+    MakeMultipartBoundary = "----AMIOptixBoundary" & Format$(Now, "yyyymmddhhnnss") & CStr(Int(Rnd() * 1000000#))
+End Function
+
+Private Function BuildRentCalculatorUploadBodyBytes( _
+    localFilePath As String, _
+    remoteFileName As String, _
+    overwrite As Boolean, _
+    boundary As String _
+) As Variant
+    Dim fileBytes As Variant
+    fileBytes = ReadBinaryFileBytes(localFilePath)
+
+    Dim safeName As String
+    safeName = Replace(CStr(remoteFileName), """", "_")
+
+    Dim prefix As String
+    prefix = "--" & boundary & vbCrLf & _
+             "Content-Disposition: form-data; name=""overwrite""" & vbCrLf & vbCrLf & _
+             IIf(overwrite, "true", "false") & vbCrLf & _
+             "--" & boundary & vbCrLf & _
+             "Content-Disposition: form-data; name=""file""; filename=""" & safeName & """" & vbCrLf & _
+             "Content-Type: application/octet-stream" & vbCrLf & vbCrLf
+
+    Dim suffix As String
+    suffix = vbCrLf & "--" & boundary & "--" & vbCrLf
+
+    Dim stm As Object
+    Set stm = CreateObject("ADODB.Stream")
+    stm.Type = 1 ' adTypeBinary
+    stm.Open
+    stm.Write StrToBytes(prefix)
+    stm.Write fileBytes
+    stm.Write StrToBytes(suffix)
+    stm.Position = 0
+    BuildRentCalculatorUploadBodyBytes = stm.Read
+    stm.Close
+End Function
+
+Private Function ReadBinaryFileBytes(filePath As String) As Variant
+    Dim stm As Object
+    Set stm = CreateObject("ADODB.Stream")
+    stm.Type = 1 ' adTypeBinary
+    stm.Open
+    stm.LoadFromFile filePath
+    ReadBinaryFileBytes = stm.Read
+    stm.Close
+End Function
+
+Private Function StrToBytes(s As String) As Variant
+    StrToBytes = StrConv(CStr(s), vbFromUnicode)
+End Function
 
 Public Function CallOptimizeAPI(payload As String) As String
     ' Makes POST request to /api/optimize endpoint
@@ -23,6 +298,11 @@ Public Function CallOptimizeAPI(payload As String) As String
     Dim t0 As Double
 
     On Error GoTo ErrorHandler
+
+    If Not EnsureSelectedRentRollYearActive(True) Then
+        CallOptimizeAPI = ""
+        Exit Function
+    End If
 
     url = API_BASE_URL & "/api/optimize"
     t0 = Timer
@@ -126,6 +406,11 @@ Public Function CallEvaluateAPI(payload As String) As String
 
     On Error GoTo ErrorHandler
 
+    If Not EnsureSelectedRentRollYearActive(True) Then
+        CallEvaluateAPI = ""
+        Exit Function
+    End If
+
     url = API_BASE_URL & "/api/evaluate"
     apiKey = GetAPIKey()
 
@@ -172,6 +457,11 @@ Public Function CallManualCalculateAPI(payload As String) As String
     Dim apiKey As String
 
     On Error GoTo ErrorHandler
+
+    If Not EnsureSelectedRentRollYearActive(True) Then
+        CallManualCalculateAPI = ""
+        Exit Function
+    End If
 
     url = API_BASE_URL & "/api/manual_calculate"
     apiKey = GetAPIKey()

--- a/excel-addin/src/AMI_Optix_Ribbon.bas
+++ b/excel-addin/src/AMI_Optix_Ribbon.bas
@@ -10,6 +10,18 @@ Private m_RentRollSheets() As String
 Private m_RentRollCount As Long
 Private m_SelectedRentRoll As String
 
+' Rent roll year selector (server-side rent calculator)
+Private Const AMI_OPTIX_REGISTRY_PATH As String = "AMI_Optix"
+Private Const RENTROLL_YEAR_MIN As Long = 2022
+Private Const RENTROLL_YEAR_MAX As Long = 2026
+Private Const RENTROLL_YEAR_DEFAULT As Long = 2025
+Private Const RENTROLL_YEAR_REG_SECTION As String = "RentRollYears"
+Private Const RENTROLL_YEAR_REG_KEY_SELECTED As String = "SelectedYear"
+Private Const RENTROLL_YEAR_REG_KEY_REMOTE_PREFIX As String = "RemoteFilename_"
+
+Private m_SelectedRentRollYear As Long
+Private m_RentRollYearInitialized As Boolean
+
 '-------------------------------------------------------------------------------
 ' RIBBON CALLBACKS - SOLVER GROUP
 '-------------------------------------------------------------------------------
@@ -657,6 +669,120 @@ End Sub
 ' RIBBON CALLBACKS - RENT ROLL GROUP
 '-------------------------------------------------------------------------------
 
+Public Sub Ribbon_SelectRentRollYear(control As IRibbonControl, id As String, index As Integer)
+    ' Called when user selects a year from dropdown (2022-2026).
+    InitRentRollYearState
+
+    Dim year As Long
+    year = RENTROLL_YEAR_MIN + CLng(index)
+    If year < RENTROLL_YEAR_MIN Or year > RENTROLL_YEAR_MAX Then Exit Sub
+
+    m_SelectedRentRollYear = year
+    SaveSetting AMI_OPTIX_REGISTRY_PATH, RENTROLL_YEAR_REG_SECTION, RENTROLL_YEAR_REG_KEY_SELECTED, CStr(year)
+    DebugLog "Ribbon_SelectRentRollYear: selected=" & year, True
+
+    ' Best-effort: ensure the API uses the selected year (rent calculator activation is server-global).
+    Call EnsureSelectedRentRollYearActive(True)
+
+    Call MaybeWarnRentRollYearMismatch(year)
+End Sub
+
+Public Sub Ribbon_GetRentRollYearCount(control As IRibbonControl, ByRef returnedVal)
+    ' NOTE: RibbonX passes this ByRef as a Variant; keep it untyped to avoid "Type mismatch".
+    returnedVal = (RENTROLL_YEAR_MAX - RENTROLL_YEAR_MIN + 1)
+End Sub
+
+Public Sub Ribbon_GetRentRollYearLabel(control As IRibbonControl, index As Integer, ByRef returnedVal)
+    ' NOTE: RibbonX passes returnedVal ByRef as a Variant.
+    Dim year As Long
+    year = RENTROLL_YEAR_MIN + CLng(index)
+    If year < RENTROLL_YEAR_MIN Or year > RENTROLL_YEAR_MAX Then
+        returnedVal = ""
+    Else
+        returnedVal = CStr(year)
+    End If
+End Sub
+
+Public Sub Ribbon_GetRentRollYearID(control As IRibbonControl, index As Integer, ByRef returnedVal)
+    ' NOTE: RibbonX passes returnedVal ByRef as a Variant.
+    returnedVal = "rryear_" & index
+End Sub
+
+Public Sub Ribbon_GetRentRollYearSelectedIndex(control As IRibbonControl, ByRef returnedVal)
+    ' NOTE: RibbonX passes returnedVal ByRef as a Variant.
+    InitRentRollYearState
+
+    Dim idx As Long
+    idx = CLng(m_SelectedRentRollYear - RENTROLL_YEAR_MIN)
+    If idx < 0 Or idx > (RENTROLL_YEAR_MAX - RENTROLL_YEAR_MIN) Then
+        idx = CLng(RENTROLL_YEAR_DEFAULT - RENTROLL_YEAR_MIN)
+    End If
+    returnedVal = idx
+End Sub
+
+Public Sub Ribbon_ManageRentRollYears(control As IRibbonControl)
+    ' Upload/replace year calculator files and activate on the API.
+    ' UI is intentionally lightweight (FileDialog) to avoid adding new UserForm files.
+    On Error GoTo Fail
+
+    InitRentRollYearState
+
+    Dim year As Long
+    year = m_SelectedRentRollYear
+
+    If ActiveWorkbook Is Nothing Then
+        MsgBox "Open a workbook first.", vbExclamation, "AMI Optix"
+        Exit Sub
+    End If
+
+    Dim fd As Object
+    Set fd = Application.FileDialog(3) ' msoFileDialogFilePicker
+    If fd Is Nothing Then Exit Sub
+
+    With fd
+        .Title = "Select rent calculator workbook for year " & CStr(year)
+        .AllowMultiSelect = False
+        .Filters.Clear
+        .Filters.Add "Excel Workbooks", "*.xlsx; *.xlsm"
+        If .Show <> -1 Then Exit Sub
+    End With
+
+    Dim selectedPath As String
+    selectedPath = CStr(fd.SelectedItems(1))
+    If Trim$(selectedPath) = "" Then Exit Sub
+
+    Dim yearFolder As String
+    yearFolder = EnsureRentRollYearFolder(year)
+    If Trim$(yearFolder) = "" Then
+        MsgBox "Could not create Rent Roll Years folder under %APPDATA%.", vbExclamation, "AMI Optix"
+        Exit Sub
+    End If
+
+    Dim localPath As String
+    localPath = yearFolder & "\RentCalculator_" & CStr(year) & ".xlsx"
+
+    Dim fso As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    If fso Is Nothing Then
+        MsgBox "File system access is unavailable.", vbExclamation, "AMI Optix"
+        Exit Sub
+    End If
+
+    fso.CopyFile selectedPath, localPath, True
+
+    Dim remoteName As String
+    remoteName = RentCalculatorRemoteNameForYear(year)
+
+    If Not UploadRentCalculatorFile(localPath, remoteName, True, True) Then Exit Sub
+    If Not ActivateRentCalculatorByName(remoteName, True) Then Exit Sub
+
+    MsgBox "Uploaded and activated rent calculator for year " & CStr(year) & ".", vbInformation, "AMI Optix"
+    Exit Sub
+
+Fail:
+    MsgBox "Manage Rent Roll Years failed: " & Err.Description, vbExclamation, "AMI Optix"
+End Sub
+
 Public Sub Ribbon_SelectRentRoll(control As IRibbonControl, id As String, index As Integer)
     ' Called when user selects a rent roll from dropdown
     If index >= 0 And index < m_RentRollCount Then
@@ -1274,4 +1400,140 @@ Private Function ScenarioPickerLine(index As Long, scenarioKey As String, scenar
 
     ScenarioPickerLine = index & ". " & FormatScenarioNameForPicker(CStr(scenarioKey)) & _
                          " [" & tierLabel & "] (WAAMI: " & waami & ")"
+End Function
+
+Private Sub InitRentRollYearState()
+    If m_RentRollYearInitialized Then Exit Sub
+
+    Dim raw As String
+    raw = GetSetting(AMI_OPTIX_REGISTRY_PATH, RENTROLL_YEAR_REG_SECTION, RENTROLL_YEAR_REG_KEY_SELECTED, CStr(RENTROLL_YEAR_DEFAULT))
+
+    Dim y As Long
+    y = RENTROLL_YEAR_DEFAULT
+    On Error Resume Next
+    y = CLng(raw)
+    On Error GoTo 0
+
+    If y < RENTROLL_YEAR_MIN Or y > RENTROLL_YEAR_MAX Then y = RENTROLL_YEAR_DEFAULT
+
+    m_SelectedRentRollYear = y
+    m_RentRollYearInitialized = True
+End Sub
+
+Private Function EnsureRentRollYearFolder(year As Long) As String
+    ' Ensure: %APPDATA%\AMI_Optix\RentRollYears\<year>\
+    On Error GoTo Fail
+
+    Dim appData As String
+    appData = Environ$("APPDATA")
+    If Trim$(appData) = "" Then Exit Function
+
+    Dim basePath As String
+    basePath = appData & "\AMI_Optix"
+    Call EnsureFolderExists(basePath)
+
+    Dim yearsPath As String
+    yearsPath = basePath & "\RentRollYears"
+    Call EnsureFolderExists(yearsPath)
+
+    Dim yearPath As String
+    yearPath = yearsPath & "\" & CStr(year)
+    Call EnsureFolderExists(yearPath)
+
+    If Dir(yearPath, vbDirectory) = "" Then Exit Function
+
+    EnsureRentRollYearFolder = yearPath
+    Exit Function
+
+Fail:
+End Function
+
+Private Function RentCalculatorRemoteNameForYear(year As Long) As String
+    RentCalculatorRemoteNameForYear = "AMI_Optix_Rent_Calculator_" & CStr(year) & ".xlsx"
+End Function
+
+Private Sub MaybeWarnRentRollYearMismatch(selectedYear As Long)
+    ' Best-effort warning only; OK continues (not blocking).
+    On Error GoTo Fail
+
+    Dim declaredYear As Long
+    declaredYear = DetectWorkbookDeclaredRentRollYear()
+    If declaredYear <= 0 Then Exit Sub
+    If declaredYear = selectedYear Then Exit Sub
+
+    MsgBox "Warning: workbook appears to declare Rent Roll year " & CStr(declaredYear) & _
+           ", but Rent Roll Year is set to " & CStr(selectedYear) & "." & vbCrLf & vbCrLf & _
+           "Click OK to continue (the selected year will be used).", _
+           vbExclamation, "AMI Optix"
+    Exit Sub
+
+Fail:
+End Sub
+
+Private Function DetectWorkbookDeclaredRentRollYear() As Long
+    ' Best-effort detection: workbook name -> rent roll sheet name -> small top-of-sheet scan.
+    On Error GoTo Fail
+
+    If ActiveWorkbook Is Nothing Then Exit Function
+
+    Dim y As Long
+    y = FindYearInText(ActiveWorkbook.Name)
+    If y > 0 Then DetectWorkbookDeclaredRentRollYear = y: Exit Function
+
+    Dim ws As Worksheet
+    Set ws = Nothing
+
+    If Trim$(m_SelectedRentRoll) <> "" Then
+        On Error Resume Next
+        Set ws = ActiveWorkbook.Worksheets(m_SelectedRentRoll)
+        On Error GoTo Fail
+    End If
+
+    If ws Is Nothing Then
+        On Error Resume Next
+        Set ws = ActiveWorkbook.Worksheets("RentRoll")
+        If ws Is Nothing Then Set ws = ActiveWorkbook.Worksheets("UAP")
+        If ws Is Nothing Then Set ws = ActiveWorkbook.Worksheets("MIH")
+        On Error GoTo Fail
+    End If
+
+    If ws Is Nothing Then Exit Function
+
+    y = FindYearInText(ws.Name)
+    If y > 0 Then DetectWorkbookDeclaredRentRollYear = y: Exit Function
+
+    Dim r As Long, c As Long
+    For r = 1 To 10
+        For c = 1 To 8
+            Dim v As Variant
+            v = ws.Cells(r, c).Value
+
+            If IsNumeric(v) Then
+                On Error Resume Next
+                y = CLng(v)
+                On Error GoTo Fail
+                If y >= RENTROLL_YEAR_MIN And y <= RENTROLL_YEAR_MAX Then
+                    DetectWorkbookDeclaredRentRollYear = y
+                    Exit Function
+                End If
+            ElseIf VarType(v) = vbString Then
+                y = FindYearInText(CStr(v))
+                If y > 0 Then DetectWorkbookDeclaredRentRollYear = y: Exit Function
+            End If
+        Next c
+    Next r
+
+    Exit Function
+
+Fail:
+End Function
+
+Private Function FindYearInText(text As String) As Long
+    Dim y As Long
+    For y = RENTROLL_YEAR_MAX To RENTROLL_YEAR_MIN Step -1
+        If InStr(1, text, CStr(y), vbTextCompare) > 0 Then
+            FindYearInText = y
+            Exit Function
+        End If
+    Next y
 End Function


### PR DESCRIPTION
Summary:
- Add Rent Roll Year dropdown (2022–2026, default 2025) and “Manage Rent Roll Years…” action in the AMI Optix ribbon.
- Persist year uploads locally under %APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\ and upload to the API rent-calculator store.
- Ensure the selected year is activated on the API before optimize/evaluate/manual-calculate calls.

Tests:
- python -m pytest -q (51 passed)

Notes:
- Rent calculator activation is server-global (/api/rent-calculators/activate); switching years affects all clients using the same API service.