### PR TITLE
Fix-01b: Utilities variant breakdown

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,147 @@
+# CODEX OPERATING PROTOCOL — NYC AMI Calculator
+
+You are working in an existing production repository. Your job is to implement small, isolated fixes without breaking established logic.
+
+## Repo + Base Branch (must be explicit)
+- Repo: martin10101/nyc-ami-calculator
+- Base branch for all fixes: perf/api-optimize-speed-2026-02-05
+
+- Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
+
+## Golden Rules
+1) One fix per iteration. Do not combine fixes.
+2) Minimal diff. No refactors, renames, formatting sweeps, or dependency changes unless explicitly required.
+3) Preserve interfaces and Excel sheet structure unless the fix explicitly changes them.
+4) Do not change solver scoring/constraints unless the fix explicitly targets solver behavior.
+5) If you think you must touch >3 files, STOP and ask for approval.
+6) Never rely on ActiveSheet to locate MIH/UAP targets unless explicitly verified safe.
+
+## Required Workflow (every session)
+### Step 0 — Read the Ledger (required)
+Open docs/CODEX_LEDGER.md and identify:
+- the next unchecked fix in the queue,
+- the last completed fix,
+- any open risks or follow-ups.
+
+### Step 1 — Create a Branch
+Create a branch from the base branch:
+- fix/<ID>-<short-slug>
+
+### Step 2 — Produce a Task Card (before coding)
+Write a Task Card that includes:
+- Goal (2–4 bullets)
+- Success Criteria
+- Files to change (exact paths)
+- Functions/entrypoints to change
+- Proposed patch (logic-level description)
+- Risk pre-mortem (how this could break things + mitigations)
+- Test plan (exact steps)
+- Rollback plan
+
+Do not code until the Task Card is written.
+
+### Step 3 — Implement
+- Only implement what was proposed in the Task Card.
+- Keep changes localized.
+- Add/adjust tests only when lightweight and aligned with repo.
+
+### Step 4 — Verify
+- Run tests if possible.
+- If you cannot run tests, provide exact manual test steps and expected outputs.
+
+### Step 5 — GitHub Push + PR (required)
+After committing:
+1) Push the branch to origin.
+2) Open a draft PR targeting the base branch (perf/api-optimize-speed-2026-02-05).
+3) Put the Fix ID in the PR title (e.g., "Fix-04: Ribbon stays active").
+
+### Step 6 — Update Ledger (required)
+Update docs/CODEX_LEDGER.md with:
+- Repo + base branch
+- Work branch + commit SHA
+- PR number/link (or "no PR")
+- Files changed
+- Summary of changes
+- Tests run + results
+- Remaining notes/risks
+- Render deploy status (see below)
+Then STOP. Do not start the next fix.
+
+---
+
+## Render Deployment Rule (GitHub-backed service)
+We want deterministic deployments tied to a commit SHA, not branch-hopping.
+
+### Current setting (do not change)
+- Auto-deploy: OFF
+- Service ID: srv-d37n6her433s73et1bp0
+
+### Behavior required from Codex
+- Do NOT trigger deployments automatically.
+- Only record the ready-to-deploy commit SHA in docs/CODEX_LEDGER.md and tell the user which commit/PR to deploy.
+
+Preferred method (manual by user):
+- User deploys from Render dashboard when ready.
+Optional method (only if user provides deploy hook secret out-of-band):
+- Trigger deploy via Render deploy hook with `ref=<commit_sha>` (deploy specific commit).
+  - Note: deploying a specific commit may disable auto-deploys until reenabled. (Render docs)
+
+Render MCP note:
+- Render MCP currently does NOT support triggering deploys or modifying existing services (except env vars). Therefore do NOT rely on MCP for branch switching or deploy triggers. (Render docs)
+
+---
+
+## Known repo-specific findings (use these to guide safe fixes)
+### 1) Scenario apply uses cached DataSheet + AMI column
+- ApplyScenarioByKey(...) in excel-addin/src/AMI_Optix_ResultsWriter.bas calls GetDataSheet() and GetAMIColumn()
+- Those are cached in excel-addin/src/AMI_Optix_DataReader.bas (m_DataSheet, m_AMICol)
+- FindDataSheet() currently prefers ActiveSheet first — this can cause wrong targeting after UI interactions
+
+### 2) Ribbon dropdown currently activates sheets + shows MsgBox
+- Ribbon_SelectRentRoll(...) in excel-addin/src/AMI_Optix_Ribbon.bas uses .Activate and MsgBox
+- Avoid doing this in dropdown callbacks; it can cause context drift and ribbon focus issues
+
+### 3) Utilities already support variants in the UI + payload
+- excel-addin/forms/frmUtilities.frm includes variant codes
+- excel-addin/src/AMI_Optix_API.bas BuildAPIPayload sends electricity/cooking/heat/hot_water
+- “only 4 utilities” symptom is likely display/mapping, not capture
+
+---
+
+## Ledger Template (create if missing)
+(If docs/CODEX_LEDGER.md does not exist, create it using the template in this section.)
+
+# CODEX LEDGER
+
+## Repo + Base Branch
+- Repo: martin10101/nyc-ami-calculator
+- Base branch: perf/api-optimize-speed-2026-02-05
+
+## Render (optional but recommended)
+- Service name:
+- Environment:
+- Service ID: srv-d37n6her433s73et1bp0
+- Auto-deploy setting (On Commit / After CI / Off): OFF
+- Deploy hook URL: [REDACTED]
+
+## Fix Queue
+- [ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+- [ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+- [ ] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+- [ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+- [ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+- [ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+## Work Log
+### YYYY-MM-DD Fix-XX <title>
+- Repo:
+- Base branch:
+- Work branch:
+- Commit:
+- PR:
+- Files changed:
+- Summary:
+- Tests run + results:
+- Render deploy: (manual; ready commit SHA recorded)
+- Notes / risks:
+- Next:

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -1,0 +1,251 @@
+\# CODEX LEDGER
+
+
+
+\## Repo + Base Branch
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+
+
+\## Render (fill once, keep updated)
+
+\- Service name:
+
+\- Environment:
+
+\- Service ID: srv-d37n6her433s73et1bp0
+
+\- Auto-deploy setting (On Commit / After CI / Off): OFF
+
+\- Deploy hook URL: \[REDACTED]
+
+
+
+\## Fix Queue
+
+\- \[x] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+
+\- \[x] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+
+\- \[x] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- \[x] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- \[ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+
+\- \[ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+
+
+\## Work Log
+
+\### 2026-02-17 Bootstrap
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: n/a
+
+\- Commit: n/a
+
+\- PR: n/a
+
+\- Files changed: CODEX.md, docs/CODEX\_LEDGER.md
+
+\- Summary: Added persistent operating protocol + ledger so Codex can resume work reliably across sessions and track repo/branch/PR and Render deploy readiness.
+
+\- Tests run + results: n/a
+
+\- Render deploy: n/a
+
+\- Notes / risks:
+
+&nbsp; - Auto-deploy is OFF; deployments are manual from Render dashboard. Record the “ready-to-deploy” commit SHA in the ledger.
+
+\- Next: Fix-01
+
+
+
+\### 2026-02-17 Fix-01 DataReader stability + remove ribbon sheet activation
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01-datareader-stability
+
+\- Commit: e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- PR: \#8 https://github.com/martin10101/nyc-ami-calculator/pull/8
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01\_DataReader\_stability.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_DataReader.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+\- Summary:
+
+&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless it's a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
+
+&nbsp; - Ribbon: rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; DebugLog).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- Notes / risks:
+
+&nbsp; - Workbooks with multiple unit-like tables may resolve to the first matching template-named sheet when the active sheet is not a known program sheet.
+
+\- Next: Fix-04
+
+
+
+\### 2026-02-18 Fix-04 Ribbon stays active (no collapsing)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/04-ribbon-stays-active
+
+\- Commit: f6792738125956226d4088d90239eba42cbfc8ff
+
+\- PR: \#9 https://github.com/martin10101/nyc-ami-calculator/pull/9
+
+\- Files changed:
+
+&nbsp; - docs/TASKCARD\_Fix-04\_Ribbon\_stays\_active.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+\- Summary:
+
+&nbsp; - Ribbon XML: add onLoad hook so VBA can capture `IRibbonUI`.
+
+&nbsp; - Ribbon callbacks: best-effort re-activate `tabAMIOptix` after `onAction` handlers so the AMI Optix tab remains selected after actions.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = f6792738125956226d4088d90239eba42cbfc8ff
+
+\- Notes / risks:
+
+&nbsp; - PR \#9 is stacked on PR \#8; merge PR \#8 first to reduce diff.
+
+\- Next: Fix-03
+
+
+
+\### 2026-02-18 Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/03-rent-roll-year-selector
+
+\- Commit: e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- PR: \#10 https://github.com/martin10101/nyc-ami-calculator/pull/10
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-03\_RentRoll\_YEAR\_selector.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_API.bas
+
+\- Summary:
+
+&nbsp; - Ribbon: add **Rent Roll Year** dropdown (2022â€“2026, default 2025) + **Manage Rent Roll Yearsâ€¦** upload/replace action.
+
+&nbsp; - Local persistence: store selected year calculators under `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`.
+
+&nbsp; - API storage: upload selected year calculator to `/api/rent-calculators/upload` and activate via `/api/rent-calculators/activate`.
+
+&nbsp; - Enforcement: API calls (optimize/evaluate/manual\_calculate) ensure the selected year is active before running.
+
+&nbsp; - Warning: best-effort mismatch warning if workbook appears to declare a different year than the selection (OK continues; not blocking).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- Notes / risks:
+
+&nbsp; - Rent calculator activation is server-global; switching years affects other clients using the same API service.
+
+&nbsp; - Declared-year detection is best-effort; some templates may not yield a detectable year (no warning shown).
+
+\- Next: Fix-01b
+
+
+\### 2026-02-18 Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01b-utilities-variant-breakdown
+
+\- Commit: 954abcfd0b957258089f54b4d5e1f7bbfc2fd73a
+
+\- PR: \#11 https://github.com/martin10101/nyc-ami-calculator/pull/11
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01b\_Utilities\_variant\_breakdown.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_ResultsWriter.bas
+
+\- Summary:
+
+&nbsp; - AMI Scenarios (top-of-sheet): utilities block now shows the exact rent roll guideline variant labels per category (no collapsed 'Gas/Oil/Electric' labels).
+
+&nbsp; - No scenario grid/per-scenario column changes.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = 954abcfd0b957258089f54b4d5e1f7bbfc2fd73a
+
+\- Notes / risks:
+
+&nbsp; - Heat labels include guideline footnote markers ('...ccASHP)1', 'Other2'), matching the rent calculator workbook.
+
+\- Next: Fix-02
+
+
+

--- a/docs/FIX_REQUIREMENTS.md
+++ b/docs/FIX_REQUIREMENTS.md
@@ -1,0 +1,280 @@
+\# FIX REQUIREMENTS — NYC AMI Calculator
+
+
+
+Base branch: perf/api-optimize-speed-2026-02-05  
+
+Repo: martin10101/nyc-ami-calculator
+
+
+
+This document defines the expected behavior for each fix.  
+
+Codex must not reinterpret these requirements.
+
+
+
+---
+
+
+
+\## Fix-01 — DataReader stability + remove ribbon sheet activation
+
+\### Problem
+
+Scenario application and other actions sometimes write to the wrong sheet/column after UI interactions because DataReader binds to ActiveSheet and ribbon callbacks activate sheets.
+
+
+
+\### Requirements
+
+\- DataReader must locate MIH/UAP target sheet and AMI column using stable anchors.
+
+\- FindDataSheet must NOT prefer ActiveSheet unless it is explicitly validated to be the MIH/UAP data sheet.
+
+\- Ribbon dropdown callbacks must NOT `.Activate` worksheets and must not use modal MsgBoxes for normal selection.
+
+\- Scenario apply must work even after any manual clears / switching sheets / using dropdowns.
+
+
+
+\### Must NOT change
+
+\- Excel sheet structure or headers.
+
+\- Solver logic.
+
+\- Scenario grid layout.
+
+
+
+\### Test (manual)
+
+\- Apply scenario #2 repeatedly while switching sheets; AMI writes always land in correct column.
+
+\- After using rent roll dropdown, apply scenario; still correct.
+
+
+
+---
+
+
+
+\## Fix-04 — Ribbon stays active (no collapsing)
+
+\### Problem
+
+AMI ribbon tab collapses/disappears after interacting with worksheet, forcing user to click AMI tab again.
+
+
+
+\### Requirements
+
+\- Selecting AMI ribbon tab should behave like normal Excel tabs: it stays active while user works.
+
+\- Dropdown selection and button clicks must not cause the tab to collapse.
+
+\- Must work consistently for all ribbon buttons (MIH + UAP).
+
+
+
+\### Must NOT change
+
+\- Any calculations.
+
+\- Any scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Open AMI tab → click a control → click worksheet cells → AMI tab remains selected.
+
+\- Repeat with dropdown controls and MIH/UAP buttons.
+
+
+
+---
+
+
+
+\## Fix-03 — Rent Roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\### Requirements
+
+\- Add ribbon year selector: 2022, 2023, 2024, 2025, 2026 (default 2025).
+
+\- Add a “Manage Rent Roll Years…” UI (form preferred) to upload/replace year files.
+
+\- Uploaded year files must persist locally (suggested: %APPDATA%\\\\AMI\_Optix\\\\RentRollYears\\\\<year>\\\\).
+
+\- Upload action should also transfer the file once to the API for storage (exact server storage mechanism can be decided, but client must not need to send files manually outside Excel).
+
+\- Selected year must override any year implied inside the active workbook’s rent roll page.
+
+\- If workbook “declared year” != selected year, show warning (OK to continue; not blocking).
+
+\- Every MIH/UAP action that uses rent roll/utilities must use the selected year.
+
+
+
+\### Must NOT change
+
+\- Scenario grid structure.
+
+\- Solver logic (except reading different year data).
+
+\- Existing rent roll math except to swap source year data.
+
+
+
+\### Test (manual)
+
+\- Upload 2022 and 2024.
+
+\- Select 2022 → run calc → confirm it uses 2022 tables.
+
+\- Workbook declares 2025 but dropdown is 2022 → warning appears; OK continues.
+
+
+
+---
+
+
+
+\## Fix-01b — Utilities variant breakdown (top-of-sheet; do not collapse)
+
+\### Problem
+
+Utilities are displayed too generically; the sheet should show which specific variants are used.
+
+
+
+\### Requirements
+
+\- Do NOT alter scenario grid structure or per-scenario columns.
+
+\- Add a top-of-sheet utility breakdown block that shows selected variants (exact names/labels as in rent roll guidelines).
+
+\- Ensure rent roll net rent uses the correct total utility allowance based on selected variants.
+
+\- Utilities are already variant-aware in the UI + payload (electricity/cooking/heat/hot\_water). Ensure display and mapping do not collapse variants incorrectly.
+
+
+
+\### Must NOT change
+
+\- Existing payload keys unless confirmed needed.
+
+\- Scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Pick a non-default heat/hot water variant → run → top-of-sheet shows exact variant and allowance matches.
+
+
+
+---
+
+
+
+\## Fix-02 — Solver dedupe identical outcomes + placement tie-break (Python)
+
+\### Problem
+
+Solver returns “duplicate-looking” scenarios that are outcome-identical but differ only by unit swaps.
+
+
+
+\### Requirements
+
+\- Only dedupe when outcomes are truly identical:
+
+&nbsp; - same AMI band mix
+
+&nbsp; - same rent outcome metrics used for client results
+
+&nbsp; - same relevant mix/sqft outcome if part of outputs
+
+\- Keep only one scenario per equivalence group.
+
+\- Choose the kept scenario using placement tie-break:
+
+&nbsp; - 40% units prefer lower floors
+
+&nbsp; - higher AMI / higher paying units prefer higher floors
+
+\- Must be surgical: do not change solver’s main scoring/constraints; apply as post-processing right before returning results.
+
+
+
+\### Test (manual or unit test)
+
+\- Two identical-outcome scenarios differing only by floor swap → only one returned, preferred placement chosen.
+
+\- Two scenarios with same AMI mix but different rent totals → BOTH remain.
+
+
+
+---
+
+
+
+\## Fix-05 — Manual working-copy always-on + 2-way sync (MIH/UAP + rent roll + year)
+
+\### Goal
+
+Remove the manual scenario on/off toggle completely and make the “manual scenario” the always-present editable working copy.
+
+
+
+\### Requirements
+
+\- There is always an editable Manual Working Copy.
+
+\- Stored solver scenarios (1..N) remain immutable.
+
+\- Selecting scenario #k copies it into Manual Working Copy and applies it to MIH/UAP, but does not change scenario #k snapshot.
+
+\- Edits to Manual Working Copy:
+
+&nbsp; - are allowed even if violating rules (warn but allow override)
+
+&nbsp; - immediately update MIH/UAP AMI column at matching unit
+
+&nbsp; - immediately update rent roll calculations (including using selected rent roll YEAR)
+
+\- Edits to MIH/UAP AMI column:
+
+&nbsp; - immediately update Manual Working Copy
+
+&nbsp; - update rent roll calculations
+
+\- Must include re-entrancy guard to prevent infinite change-event loops.
+
+
+
+\### Must NOT change
+
+\- Scenario snapshots for 1..N.
+
+\- Solver logic.
+
+\- Scenario grid structure.
+
+
+
+\### Test (manual)
+
+\- Select scenario #2 → manual reflects it; scenario #2 snapshot unchanged.
+
+\- Edit manual unit AMI → MIH/UAP updates instantly; rent roll updates.
+
+\- Edit MIH/UAP AMI cell → manual updates; rent roll updates.
+
+\- Repeat after switching sheets and switching selected rent roll year.
+
+
+

--- a/docs/TASKCARD_Fix-01b_Utilities_variant_breakdown.md
+++ b/docs/TASKCARD_Fix-01b_Utilities_variant_breakdown.md
@@ -1,0 +1,48 @@
+# Task Card — Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse)
+
+## Goal
+- Make the top-of-sheet utilities block show the **exact utility variant labels** used by the rent roll guidelines (e.g., “Gas Stove”, “Gas Heat”, “Electric Hot Water - Heat Pump”, “Electric Heat - … (ccASHP)1”).
+- Prevent “collapsed”/generic labels (e.g., showing just “Gas” for multiple utilities).
+- Keep scenario grid + per-scenario columns unchanged.
+
+## Success Criteria (from `docs/FIX_REQUIREMENTS.md`)
+- Scenario grid structure and per-scenario columns are unchanged.
+- Top-of-sheet utility breakdown block shows selected variants using the exact names/labels as the rent roll guidelines.
+- Net rent continues to reflect the correct **total** utility allowance based on the selected variants.
+- Utilities display/mapping does not collapse variants incorrectly (electricity/cooking/heat/hot_water).
+
+## Files To Change
+- `excel-addin/src/AMI_Optix_ResultsWriter.bas`
+
+## Functions / Entrypoints To Change
+- `WriteUtilitySettings(ws As Worksheet, startRow As Long) As Long`
+- Replace/extend helper: `FormatUtilityType(...)` (or introduce a category-aware label helper)
+
+## Proposed Patch (logic-level)
+- Update the utilities block writer to display **category-aware** labels:
+  - Cooking: “Electric Stove” / “Gas Stove” / “N/A or owner pays”
+  - Heat: “Electric Heat - Cold Climate Air Source Heat Pump (ccASHP)1” / “Electric Heat - Other2” / “Gas Heat” / “Oil Heat” / “N/A or owner pays”
+  - Hot Water: “Electric Hot Water - Heat Pump” / “Electric Hot Water - Other” / “Gas Hot Water” / “Oil Hot Water” / “N/A or owner pays”
+  - Electricity: “Tenant Pays” / “N/A or owner pays”
+- Keep the existing per-bedroom utility deduction totals table intact; this fix is display/mapping only.
+
+## Risk Pre‑Mortem
+- **Risk:** Labels drift from the backend/rent workbook over time.
+  - **Mitigation:** Use strings that match the documented guideline labels and current rent calculator workbook labels (including the “1”/“2” heat footnotes).
+- **Risk:** Changing the number of rows in the utilities block shifts where the manual scenario table starts.
+  - **Mitigation:** Only change displayed strings (not row structure) so downstream row offsets remain stable.
+
+## Test Plan
+### Automated
+- `python -m pytest -q`
+
+### Manual (Excel)
+- Open a workbook, set a **non-default** Heat and/or Hot Water variant (e.g., Heat = ccASHP, Hot Water = Gas).
+- Run Optimize / Evaluate.
+- In the “AMI Scenarios” sheet top block:
+  - Verify the utilities table shows the exact variant labels (not generic “Gas/Oil/Electric”).
+  - Verify the per-bedroom utility deduction totals change appropriately when switching variants.
+
+## Rollback Plan
+- Revert commit on this branch, or restore prior `WriteUtilitySettings` label formatting in `excel-addin/src/AMI_Optix_ResultsWriter.bas`.
+

--- a/excel-addin/src/AMI_Optix_ResultsWriter.bas
+++ b/excel-addin/src/AMI_Optix_ResultsWriter.bas
@@ -1525,7 +1525,7 @@ Private Function WriteUtilitySettings(ws As Worksheet, startRow As Long) As Long
     row = startRow
 
     ' Header
-    ws.Cells(row, 1).Value = "TENANT-PAID UTILITIES - Affects Rent Allowances"
+    ws.Cells(row, 1).Value = "UTILITIES - Selected Variants (Affects Rent Allowances)"
     ws.Cells(row, 1).Font.Bold = True
     ws.Cells(row, 1).Font.Size = 12
     ws.Range(ws.Cells(row, 1), ws.Cells(row, 4)).Interior.Color = RGB(255, 230, 200)
@@ -1548,53 +1548,49 @@ Private Function WriteUtilitySettings(ws As Worksheet, startRow As Long) As Long
 
     ' Electricity
     ws.Cells(row, 1).Value = "Electricity"
+    ws.Cells(row, 3).Value = FormatUtilityType(elec, "electricity")
     If elec = "tenant_pays" Then
         ws.Cells(row, 2).Value = "YES"
         ws.Cells(row, 2).Font.Color = RGB(0, 128, 0)
-        ws.Cells(row, 3).Value = "Standard"
     Else
         ws.Cells(row, 2).Value = "NO"
         ws.Cells(row, 2).Font.Color = RGB(128, 128, 128)
-        ws.Cells(row, 3).Value = "Owner Pays"
     End If
     row = row + 1
 
     ' Cooking
     ws.Cells(row, 1).Value = "Cooking"
+    ws.Cells(row, 3).Value = FormatUtilityType(cook, "cooking")
     If cook <> "na" Then
         ws.Cells(row, 2).Value = "YES"
         ws.Cells(row, 2).Font.Color = RGB(0, 128, 0)
-        ws.Cells(row, 3).Value = FormatUtilityType(cook)
     Else
         ws.Cells(row, 2).Value = "NO"
         ws.Cells(row, 2).Font.Color = RGB(128, 128, 128)
-        ws.Cells(row, 3).Value = "Owner Pays"
     End If
     row = row + 1
 
     ' Heat
     ws.Cells(row, 1).Value = "Heat"
+    ws.Cells(row, 3).Value = FormatUtilityType(heat, "heat")
     If heat <> "na" Then
         ws.Cells(row, 2).Value = "YES"
         ws.Cells(row, 2).Font.Color = RGB(0, 128, 0)
-        ws.Cells(row, 3).Value = FormatUtilityType(heat)
     Else
         ws.Cells(row, 2).Value = "NO"
         ws.Cells(row, 2).Font.Color = RGB(128, 128, 128)
-        ws.Cells(row, 3).Value = "Owner Pays"
     End If
     row = row + 1
 
     ' Hot Water
     ws.Cells(row, 1).Value = "Hot Water"
+    ws.Cells(row, 3).Value = FormatUtilityType(hw, "hot_water")
     If hw <> "na" Then
         ws.Cells(row, 2).Value = "YES"
         ws.Cells(row, 2).Font.Color = RGB(0, 128, 0)
-        ws.Cells(row, 3).Value = FormatUtilityType(hw)
     Else
         ws.Cells(row, 2).Value = "NO"
         ws.Cells(row, 2).Font.Color = RGB(128, 128, 128)
-        ws.Cells(row, 3).Value = "Owner Pays"
     End If
     row = row + 1
 
@@ -1840,17 +1836,62 @@ Fail:
     AllowanceAmountFromDict = 0#
 End Function
 
-Private Function FormatUtilityType(value As String) As String
-    ' Formats utility type code to display name
-    Select Case value
-        Case "electric", "electric_stove": FormatUtilityType = "Electric"
+Private Function FormatUtilityType(value As String, Optional category As String = "") As String
+    ' Formats utility selection codes to the exact rent roll guideline labels (do not collapse variants).
+    Dim v As String
+    Dim c As String
+    v = LCase$(Trim$(CStr(value)))
+    c = LCase$(Trim$(CStr(category)))
+
+    Select Case c
+        Case "electricity"
+            If v = "tenant_pays" Then
+                FormatUtilityType = "Tenant Pays"
+            Else
+                FormatUtilityType = "N/A or owner pays"
+            End If
+            Exit Function
+
+        Case "cooking"
+            Select Case v
+                Case "electric", "electric_stove": FormatUtilityType = "Electric Stove"
+                Case "gas": FormatUtilityType = "Gas Stove"
+                Case Else: FormatUtilityType = "N/A or owner pays"
+            End Select
+            Exit Function
+
+        Case "heat"
+            Select Case v
+                Case "electric_ccashp": FormatUtilityType = "Electric Heat - Cold Climate Air Source Heat Pump (ccASHP)1"
+                Case "electric_other": FormatUtilityType = "Electric Heat - Other2"
+                Case "gas": FormatUtilityType = "Gas Heat"
+                Case "oil": FormatUtilityType = "Oil Heat"
+                Case Else: FormatUtilityType = "N/A or owner pays"
+            End Select
+            Exit Function
+
+        Case "hot_water"
+            Select Case v
+                Case "electric_heat_pump": FormatUtilityType = "Electric Hot Water - Heat Pump"
+                Case "electric_other": FormatUtilityType = "Electric Hot Water - Other"
+                Case "gas": FormatUtilityType = "Gas Hot Water"
+                Case "oil": FormatUtilityType = "Oil Hot Water"
+                Case Else: FormatUtilityType = "N/A or owner pays"
+            End Select
+            Exit Function
+    End Select
+
+    ' Backward-compatible fallback (should not be used when category is provided).
+    Select Case v
+        Case "electric", "electric_stove": FormatUtilityType = "Electric Stove"
         Case "gas": FormatUtilityType = "Gas"
         Case "oil": FormatUtilityType = "Oil"
         Case "electric_ccashp": FormatUtilityType = "Electric (ccASHP)"
         Case "electric_other": FormatUtilityType = "Electric (Other)"
         Case "electric_heat_pump": FormatUtilityType = "Electric (Heat Pump)"
-        Case "tenant_pays": FormatUtilityType = "Standard"
-        Case Else: FormatUtilityType = value
+        Case "tenant_pays": FormatUtilityType = "Tenant Pays"
+        Case "na", "": FormatUtilityType = "N/A or owner pays"
+        Case Else: FormatUtilityType = CStr(value)
     End Select
 End Function
 


### PR DESCRIPTION
Goal: show exact utility variant labels (no collapsed 'Gas/Oil/Electric').\n\nChanges:\n- AMI Scenarios: utilities block now displays rent-roll guideline labels per category (Cooking/Heat/Hot Water/Electricity).\n- Keeps scenario grid + per-scenario columns unchanged.\n\nTests:\n- python -m pytest -q (51 passed)