### PR TITLE
Fix-02: De-dupe outcome-identical scenarios

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,147 @@
+# CODEX OPERATING PROTOCOL — NYC AMI Calculator
+
+You are working in an existing production repository. Your job is to implement small, isolated fixes without breaking established logic.
+
+## Repo + Base Branch (must be explicit)
+- Repo: martin10101/nyc-ami-calculator
+- Base branch for all fixes: perf/api-optimize-speed-2026-02-05
+
+- Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
+
+## Golden Rules
+1) One fix per iteration. Do not combine fixes.
+2) Minimal diff. No refactors, renames, formatting sweeps, or dependency changes unless explicitly required.
+3) Preserve interfaces and Excel sheet structure unless the fix explicitly changes them.
+4) Do not change solver scoring/constraints unless the fix explicitly targets solver behavior.
+5) If you think you must touch >3 files, STOP and ask for approval.
+6) Never rely on ActiveSheet to locate MIH/UAP targets unless explicitly verified safe.
+
+## Required Workflow (every session)
+### Step 0 — Read the Ledger (required)
+Open docs/CODEX_LEDGER.md and identify:
+- the next unchecked fix in the queue,
+- the last completed fix,
+- any open risks or follow-ups.
+
+### Step 1 — Create a Branch
+Create a branch from the base branch:
+- fix/<ID>-<short-slug>
+
+### Step 2 — Produce a Task Card (before coding)
+Write a Task Card that includes:
+- Goal (2–4 bullets)
+- Success Criteria
+- Files to change (exact paths)
+- Functions/entrypoints to change
+- Proposed patch (logic-level description)
+- Risk pre-mortem (how this could break things + mitigations)
+- Test plan (exact steps)
+- Rollback plan
+
+Do not code until the Task Card is written.
+
+### Step 3 — Implement
+- Only implement what was proposed in the Task Card.
+- Keep changes localized.
+- Add/adjust tests only when lightweight and aligned with repo.
+
+### Step 4 — Verify
+- Run tests if possible.
+- If you cannot run tests, provide exact manual test steps and expected outputs.
+
+### Step 5 — GitHub Push + PR (required)
+After committing:
+1) Push the branch to origin.
+2) Open a draft PR targeting the base branch (perf/api-optimize-speed-2026-02-05).
+3) Put the Fix ID in the PR title (e.g., "Fix-04: Ribbon stays active").
+
+### Step 6 — Update Ledger (required)
+Update docs/CODEX_LEDGER.md with:
+- Repo + base branch
+- Work branch + commit SHA
+- PR number/link (or "no PR")
+- Files changed
+- Summary of changes
+- Tests run + results
+- Remaining notes/risks
+- Render deploy status (see below)
+Then STOP. Do not start the next fix.
+
+---
+
+## Render Deployment Rule (GitHub-backed service)
+We want deterministic deployments tied to a commit SHA, not branch-hopping.
+
+### Current setting (do not change)
+- Auto-deploy: OFF
+- Service ID: srv-d37n6her433s73et1bp0
+
+### Behavior required from Codex
+- Do NOT trigger deployments automatically.
+- Only record the ready-to-deploy commit SHA in docs/CODEX_LEDGER.md and tell the user which commit/PR to deploy.
+
+Preferred method (manual by user):
+- User deploys from Render dashboard when ready.
+Optional method (only if user provides deploy hook secret out-of-band):
+- Trigger deploy via Render deploy hook with `ref=<commit_sha>` (deploy specific commit).
+  - Note: deploying a specific commit may disable auto-deploys until reenabled. (Render docs)
+
+Render MCP note:
+- Render MCP currently does NOT support triggering deploys or modifying existing services (except env vars). Therefore do NOT rely on MCP for branch switching or deploy triggers. (Render docs)
+
+---
+
+## Known repo-specific findings (use these to guide safe fixes)
+### 1) Scenario apply uses cached DataSheet + AMI column
+- ApplyScenarioByKey(...) in excel-addin/src/AMI_Optix_ResultsWriter.bas calls GetDataSheet() and GetAMIColumn()
+- Those are cached in excel-addin/src/AMI_Optix_DataReader.bas (m_DataSheet, m_AMICol)
+- FindDataSheet() currently prefers ActiveSheet first — this can cause wrong targeting after UI interactions
+
+### 2) Ribbon dropdown currently activates sheets + shows MsgBox
+- Ribbon_SelectRentRoll(...) in excel-addin/src/AMI_Optix_Ribbon.bas uses .Activate and MsgBox
+- Avoid doing this in dropdown callbacks; it can cause context drift and ribbon focus issues
+
+### 3) Utilities already support variants in the UI + payload
+- excel-addin/forms/frmUtilities.frm includes variant codes
+- excel-addin/src/AMI_Optix_API.bas BuildAPIPayload sends electricity/cooking/heat/hot_water
+- “only 4 utilities” symptom is likely display/mapping, not capture
+
+---
+
+## Ledger Template (create if missing)
+(If docs/CODEX_LEDGER.md does not exist, create it using the template in this section.)
+
+# CODEX LEDGER
+
+## Repo + Base Branch
+- Repo: martin10101/nyc-ami-calculator
+- Base branch: perf/api-optimize-speed-2026-02-05
+
+## Render (optional but recommended)
+- Service name:
+- Environment:
+- Service ID: srv-d37n6her433s73et1bp0
+- Auto-deploy setting (On Commit / After CI / Off): OFF
+- Deploy hook URL: [REDACTED]
+
+## Fix Queue
+- [ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+- [ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+- [ ] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+- [ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+- [ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+- [ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+## Work Log
+### YYYY-MM-DD Fix-XX <title>
+- Repo:
+- Base branch:
+- Work branch:
+- Commit:
+- PR:
+- Files changed:
+- Summary:
+- Tests run + results:
+- Render deploy: (manual; ready commit SHA recorded)
+- Notes / risks:
+- Next:

--- a/app.py
+++ b/app.py
@@ -969,6 +969,166 @@ def optimize_units():
                     notes.append(f"Warning: Could not compute edge scenarios: {str(e)}")
                 timing["edge_scenarios_ms"] = int(round((time.perf_counter() - edge_start) * 1000))
 
+        # --- Fix-02: De-dupe outcome-identical scenarios (post-processing) ---
+        # Only remove scenarios when they are truly identical in outputs (band mix + rent totals),
+        # then keep the best "placement" (40% units lower floors; higher AMI/higher rent higher floors).
+        try:
+            scenario_priority = [
+                "absolute_best",
+                "best_3_band",
+                "best_2_band",
+                "alternative",
+                "client_oriented",
+                "max_revenue",
+            ]
+            priority_index = {k: i for i, k in enumerate(scenario_priority)}
+
+            def _outcome_signature(scenario: dict) -> tuple | None:
+                if not scenario:
+                    return None
+
+                metrics = scenario.get("metrics") or {}
+                band_mix = metrics.get("band_mix") or []
+                rent_totals = scenario.get("rent_totals") or {}
+
+                # Be conservative: if we don't have rent totals, we can't safely claim outcomes match.
+                if not band_mix:
+                    return None
+                if "net_monthly" not in rent_totals or "net_annual" not in rent_totals:
+                    return None
+
+                mix_items: list[tuple[int, int, float]] = []
+                for item in band_mix:
+                    if not isinstance(item, dict):
+                        return None
+                    try:
+                        band = int(item.get("band"))
+                    except Exception:
+                        return None
+                    try:
+                        units = int(item.get("units") or 0)
+                    except Exception:
+                        units = 0
+                    try:
+                        net_sf = round(float(item.get("net_sf") or 0.0), 2)
+                    except Exception:
+                        net_sf = 0.0
+                    mix_items.append((band, units, net_sf))
+                mix_items.sort(key=lambda x: x[0])
+
+                try:
+                    net_monthly = round(float(rent_totals.get("net_monthly")), 2)
+                    net_annual = round(float(rent_totals.get("net_annual")), 2)
+                except Exception:
+                    return None
+
+                try:
+                    total_sf = round(float(metrics.get("total_sf") or 0.0), 2)
+                except Exception:
+                    total_sf = 0.0
+                try:
+                    waami = round(float(scenario.get("waami") or 0.0), 10)
+                except Exception:
+                    waami = 0.0
+
+                return (tuple(mix_items), net_monthly, net_annual, total_sf, waami)
+
+            def _placement_key(scenario: dict) -> tuple:
+                assignments = (scenario or {}).get("assignments") or []
+                floors: list[float] = []
+                bands: list[float] = []
+                rents: list[float] = []
+
+                for unit in assignments:
+                    if not isinstance(unit, dict):
+                        continue
+                    try:
+                        floor = float(unit.get("floor") or 0.0)
+                    except Exception:
+                        floor = 0.0
+                    try:
+                        band = float(unit.get("assigned_ami") or 0.0)
+                    except Exception:
+                        band = 0.0
+                    try:
+                        rent = float(unit.get("monthly_rent") or 0.0)
+                    except Exception:
+                        rent = 0.0
+                    floors.append(floor)
+                    bands.append(band)
+                    rents.append(rent)
+
+                # Count "inversions" where lower AMI is placed above higher AMI (or vice versa).
+                inversions = 0
+                n = len(floors)
+                for i in range(n):
+                    for j in range(i + 1, n):
+                        if (bands[i] < bands[j] and floors[i] > floors[j]) or (bands[i] > bands[j] and floors[i] < floors[j]):
+                            inversions += 1
+
+                align_ami = sum(f * b for f, b in zip(floors, bands))
+                align_rent = sum(f * r for f, r in zip(floors, rents))
+                low40_floor_sum = sum(f for f, b in zip(floors, bands) if b <= 0.4000001)
+
+                # Higher is better (fewer inversions; better alignment; 40% units lower floors).
+                return (-inversions, align_ami, align_rent, -low40_floor_sum)
+
+            groups: dict[tuple, list[str]] = {}
+            for key, scenario in (scenarios or {}).items():
+                sig = _outcome_signature(scenario)
+                if sig is None:
+                    continue
+                groups.setdefault(sig, []).append(str(key))
+
+            removed = 0
+            if groups:
+                for sig, keys in groups.items():
+                    if len(keys) < 2:
+                        continue
+
+                    def _keeper_sort_key(k: str) -> tuple:
+                        return (priority_index.get(k, 10_000), k)
+
+                    keep_key = sorted(keys, key=_keeper_sort_key)[0]
+
+                    # Prefer non-edge scenarios when available, then apply placement tie-break.
+                    candidates = []
+                    for k in keys:
+                        sc = (scenarios or {}).get(k)
+                        if not sc:
+                            continue
+                        tier = str(sc.get("tier") or "").strip().lower()
+                        is_edge = (tier == "edge")
+                        candidates.append((is_edge, _placement_key(sc), k, sc))
+                    if not candidates:
+                        continue
+
+                    strict_candidates = [c for c in candidates if not c[0]]
+                    pool = strict_candidates if strict_candidates else candidates
+                    winner = max(
+                        pool,
+                        key=lambda c: (
+                            c[1],
+                            -priority_index.get(c[2], 10_000),
+                            c[2],
+                        ),
+                    )
+                    winner_key = winner[2]
+                    winner_scenario = winner[3]
+
+                    scenarios[keep_key] = winner_scenario
+                    for k in keys:
+                        if k == keep_key:
+                            continue
+                        if k in scenarios:
+                            del scenarios[k]
+                            removed += 1
+
+            if removed > 0:
+                notes.append(f"De-duped {removed} outcome-identical scenario(s) (Fix-02).")
+        except Exception:
+            pass
+
         learning_info = None
         if compare_baseline and baseline_scenarios and scenarios:
             def _scenario_snapshot(scenarios_dict: dict) -> dict:

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -1,0 +1,292 @@
+\# CODEX LEDGER
+
+
+
+\## Repo + Base Branch
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+
+
+\## Render (fill once, keep updated)
+
+\- Service name:
+
+\- Environment:
+
+\- Service ID: srv-d37n6her433s73et1bp0
+
+\- Auto-deploy setting (On Commit / After CI / Off): OFF
+
+\- Deploy hook URL: \[REDACTED]
+
+
+
+\## Fix Queue
+
+\- \[x] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+
+\- \[x] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+
+\- \[x] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- \[x] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- \[x] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+
+\- \[ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+
+
+\## Work Log
+
+\### 2026-02-17 Bootstrap
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: n/a
+
+\- Commit: n/a
+
+\- PR: n/a
+
+\- Files changed: CODEX.md, docs/CODEX\_LEDGER.md
+
+\- Summary: Added persistent operating protocol + ledger so Codex can resume work reliably across sessions and track repo/branch/PR and Render deploy readiness.
+
+\- Tests run + results: n/a
+
+\- Render deploy: n/a
+
+\- Notes / risks:
+
+&nbsp; - Auto-deploy is OFF; deployments are manual from Render dashboard. Record the “ready-to-deploy” commit SHA in the ledger.
+
+\- Next: Fix-01
+
+
+
+\### 2026-02-17 Fix-01 DataReader stability + remove ribbon sheet activation
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01-datareader-stability
+
+\- Commit: e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- PR: \#8 https://github.com/martin10101/nyc-ami-calculator/pull/8
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01\_DataReader\_stability.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_DataReader.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+\- Summary:
+
+&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless it's a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
+
+&nbsp; - Ribbon: rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; DebugLog).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- Notes / risks:
+
+&nbsp; - Workbooks with multiple unit-like tables may resolve to the first matching template-named sheet when the active sheet is not a known program sheet.
+
+\- Next: Fix-04
+
+
+
+\### 2026-02-18 Fix-04 Ribbon stays active (no collapsing)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/04-ribbon-stays-active
+
+\- Commit: f6792738125956226d4088d90239eba42cbfc8ff
+
+\- PR: \#9 https://github.com/martin10101/nyc-ami-calculator/pull/9
+
+\- Files changed:
+
+&nbsp; - docs/TASKCARD\_Fix-04\_Ribbon\_stays\_active.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+\- Summary:
+
+&nbsp; - Ribbon XML: add onLoad hook so VBA can capture `IRibbonUI`.
+
+&nbsp; - Ribbon callbacks: best-effort re-activate `tabAMIOptix` after `onAction` handlers so the AMI Optix tab remains selected after actions.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = f6792738125956226d4088d90239eba42cbfc8ff
+
+\- Notes / risks:
+
+&nbsp; - PR \#9 is stacked on PR \#8; merge PR \#8 first to reduce diff.
+
+\- Next: Fix-03
+
+
+
+\### 2026-02-18 Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/03-rent-roll-year-selector
+
+\- Commit: e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- PR: \#10 https://github.com/martin10101/nyc-ami-calculator/pull/10
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-03\_RentRoll\_YEAR\_selector.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_API.bas
+
+\- Summary:
+
+&nbsp; - Ribbon: add **Rent Roll Year** dropdown (2022â€“2026, default 2025) + **Manage Rent Roll Yearsâ€¦** upload/replace action.
+
+&nbsp; - Local persistence: store selected year calculators under `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`.
+
+&nbsp; - API storage: upload selected year calculator to `/api/rent-calculators/upload` and activate via `/api/rent-calculators/activate`.
+
+&nbsp; - Enforcement: API calls (optimize/evaluate/manual\_calculate) ensure the selected year is active before running.
+
+&nbsp; - Warning: best-effort mismatch warning if workbook appears to declare a different year than the selection (OK continues; not blocking).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- Notes / risks:
+
+&nbsp; - Rent calculator activation is server-global; switching years affects other clients using the same API service.
+
+&nbsp; - Declared-year detection is best-effort; some templates may not yield a detectable year (no warning shown).
+
+\- Next: Fix-01b
+
+
+\### 2026-02-18 Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01b-utilities-variant-breakdown
+
+\- Commit: 954abcfd0b957258089f54b4d5e1f7bbfc2fd73a
+
+\- PR: \#11 https://github.com/martin10101/nyc-ami-calculator/pull/11
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01b\_Utilities\_variant\_breakdown.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_ResultsWriter.bas
+
+\- Summary:
+
+&nbsp; - AMI Scenarios (top-of-sheet): utilities block now shows the exact rent roll guideline variant labels per category (no collapsed 'Gas/Oil/Electric' labels).
+
+&nbsp; - No scenario grid/per-scenario column changes.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = 954abcfd0b957258089f54b4d5e1f7bbfc2fd73a
+
+\- Notes / risks:
+
+&nbsp; - Heat labels include guideline footnote markers ('...ccASHP)1', 'Other2'), matching the rent calculator workbook.
+
+\- Next: Fix-02
+
+
+\### 2026-02-18 Fix-02 Solver dedupe identical outcomes + placement tie-break (Python)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/02-solver-outcome-dedupe
+
+\- Commit: acac3a76ca5760f5f3ca8fdf09cb3fd54bbfcbb8
+
+\- PR: \#12 https://github.com/martin10101/nyc-ami-calculator/pull/12
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-02\_Solver\_outcome\_dedupe.md
+
+&nbsp; - app.py
+
+\- Summary:
+
+&nbsp; - API (/api/optimize): post-process returned scenarios to remove outcome-identical duplicates (same band mix + same net rent totals), keeping the best floor placement (40% lower floors; higher AMI/rent higher floors).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = acac3a76ca5760f5f3ca8fdf09cb3fd54bbfcbb8
+
+\- Notes / risks:
+
+&nbsp; - Dedupe is conservative and only runs when rent totals are available (rent calculator loaded).
+
+&nbsp; - Edge check: Test.xlsx optimize returned 5 scenarios and reported 1 duplicate removed (Fix-02 note).
+
+\- Next: Fix-05
+
+
+

--- a/docs/FIX_REQUIREMENTS.md
+++ b/docs/FIX_REQUIREMENTS.md
@@ -1,0 +1,280 @@
+\# FIX REQUIREMENTS — NYC AMI Calculator
+
+
+
+Base branch: perf/api-optimize-speed-2026-02-05  
+
+Repo: martin10101/nyc-ami-calculator
+
+
+
+This document defines the expected behavior for each fix.  
+
+Codex must not reinterpret these requirements.
+
+
+
+---
+
+
+
+\## Fix-01 — DataReader stability + remove ribbon sheet activation
+
+\### Problem
+
+Scenario application and other actions sometimes write to the wrong sheet/column after UI interactions because DataReader binds to ActiveSheet and ribbon callbacks activate sheets.
+
+
+
+\### Requirements
+
+\- DataReader must locate MIH/UAP target sheet and AMI column using stable anchors.
+
+\- FindDataSheet must NOT prefer ActiveSheet unless it is explicitly validated to be the MIH/UAP data sheet.
+
+\- Ribbon dropdown callbacks must NOT `.Activate` worksheets and must not use modal MsgBoxes for normal selection.
+
+\- Scenario apply must work even after any manual clears / switching sheets / using dropdowns.
+
+
+
+\### Must NOT change
+
+\- Excel sheet structure or headers.
+
+\- Solver logic.
+
+\- Scenario grid layout.
+
+
+
+\### Test (manual)
+
+\- Apply scenario #2 repeatedly while switching sheets; AMI writes always land in correct column.
+
+\- After using rent roll dropdown, apply scenario; still correct.
+
+
+
+---
+
+
+
+\## Fix-04 — Ribbon stays active (no collapsing)
+
+\### Problem
+
+AMI ribbon tab collapses/disappears after interacting with worksheet, forcing user to click AMI tab again.
+
+
+
+\### Requirements
+
+\- Selecting AMI ribbon tab should behave like normal Excel tabs: it stays active while user works.
+
+\- Dropdown selection and button clicks must not cause the tab to collapse.
+
+\- Must work consistently for all ribbon buttons (MIH + UAP).
+
+
+
+\### Must NOT change
+
+\- Any calculations.
+
+\- Any scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Open AMI tab → click a control → click worksheet cells → AMI tab remains selected.
+
+\- Repeat with dropdown controls and MIH/UAP buttons.
+
+
+
+---
+
+
+
+\## Fix-03 — Rent Roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\### Requirements
+
+\- Add ribbon year selector: 2022, 2023, 2024, 2025, 2026 (default 2025).
+
+\- Add a “Manage Rent Roll Years…” UI (form preferred) to upload/replace year files.
+
+\- Uploaded year files must persist locally (suggested: %APPDATA%\\\\AMI\_Optix\\\\RentRollYears\\\\<year>\\\\).
+
+\- Upload action should also transfer the file once to the API for storage (exact server storage mechanism can be decided, but client must not need to send files manually outside Excel).
+
+\- Selected year must override any year implied inside the active workbook’s rent roll page.
+
+\- If workbook “declared year” != selected year, show warning (OK to continue; not blocking).
+
+\- Every MIH/UAP action that uses rent roll/utilities must use the selected year.
+
+
+
+\### Must NOT change
+
+\- Scenario grid structure.
+
+\- Solver logic (except reading different year data).
+
+\- Existing rent roll math except to swap source year data.
+
+
+
+\### Test (manual)
+
+\- Upload 2022 and 2024.
+
+\- Select 2022 → run calc → confirm it uses 2022 tables.
+
+\- Workbook declares 2025 but dropdown is 2022 → warning appears; OK continues.
+
+
+
+---
+
+
+
+\## Fix-01b — Utilities variant breakdown (top-of-sheet; do not collapse)
+
+\### Problem
+
+Utilities are displayed too generically; the sheet should show which specific variants are used.
+
+
+
+\### Requirements
+
+\- Do NOT alter scenario grid structure or per-scenario columns.
+
+\- Add a top-of-sheet utility breakdown block that shows selected variants (exact names/labels as in rent roll guidelines).
+
+\- Ensure rent roll net rent uses the correct total utility allowance based on selected variants.
+
+\- Utilities are already variant-aware in the UI + payload (electricity/cooking/heat/hot\_water). Ensure display and mapping do not collapse variants incorrectly.
+
+
+
+\### Must NOT change
+
+\- Existing payload keys unless confirmed needed.
+
+\- Scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Pick a non-default heat/hot water variant → run → top-of-sheet shows exact variant and allowance matches.
+
+
+
+---
+
+
+
+\## Fix-02 — Solver dedupe identical outcomes + placement tie-break (Python)
+
+\### Problem
+
+Solver returns “duplicate-looking” scenarios that are outcome-identical but differ only by unit swaps.
+
+
+
+\### Requirements
+
+\- Only dedupe when outcomes are truly identical:
+
+&nbsp; - same AMI band mix
+
+&nbsp; - same rent outcome metrics used for client results
+
+&nbsp; - same relevant mix/sqft outcome if part of outputs
+
+\- Keep only one scenario per equivalence group.
+
+\- Choose the kept scenario using placement tie-break:
+
+&nbsp; - 40% units prefer lower floors
+
+&nbsp; - higher AMI / higher paying units prefer higher floors
+
+\- Must be surgical: do not change solver’s main scoring/constraints; apply as post-processing right before returning results.
+
+
+
+\### Test (manual or unit test)
+
+\- Two identical-outcome scenarios differing only by floor swap → only one returned, preferred placement chosen.
+
+\- Two scenarios with same AMI mix but different rent totals → BOTH remain.
+
+
+
+---
+
+
+
+\## Fix-05 — Manual working-copy always-on + 2-way sync (MIH/UAP + rent roll + year)
+
+\### Goal
+
+Remove the manual scenario on/off toggle completely and make the “manual scenario” the always-present editable working copy.
+
+
+
+\### Requirements
+
+\- There is always an editable Manual Working Copy.
+
+\- Stored solver scenarios (1..N) remain immutable.
+
+\- Selecting scenario #k copies it into Manual Working Copy and applies it to MIH/UAP, but does not change scenario #k snapshot.
+
+\- Edits to Manual Working Copy:
+
+&nbsp; - are allowed even if violating rules (warn but allow override)
+
+&nbsp; - immediately update MIH/UAP AMI column at matching unit
+
+&nbsp; - immediately update rent roll calculations (including using selected rent roll YEAR)
+
+\- Edits to MIH/UAP AMI column:
+
+&nbsp; - immediately update Manual Working Copy
+
+&nbsp; - update rent roll calculations
+
+\- Must include re-entrancy guard to prevent infinite change-event loops.
+
+
+
+\### Must NOT change
+
+\- Scenario snapshots for 1..N.
+
+\- Solver logic.
+
+\- Scenario grid structure.
+
+
+
+\### Test (manual)
+
+\- Select scenario #2 → manual reflects it; scenario #2 snapshot unchanged.
+
+\- Edit manual unit AMI → MIH/UAP updates instantly; rent roll updates.
+
+\- Edit MIH/UAP AMI cell → manual updates; rent roll updates.
+
+\- Repeat after switching sheets and switching selected rent roll year.
+
+
+

--- a/docs/TASKCARD_Fix-02_Solver_outcome_dedupe.md
+++ b/docs/TASKCARD_Fix-02_Solver_outcome_dedupe.md
@@ -1,0 +1,59 @@
+# Task Card — Fix-02 Solver dedupe identical outcomes + placement tie-break (Python)
+
+## Goal
+- Remove “duplicate-looking” solver scenarios from the `/api/optimize` response when they are outcome-identical (same band mix + same rent totals), even if unit-level assignments differ.
+- Keep only one scenario per equivalence group.
+- Choose the kept scenario using placement tie-break (40% units lower floors; higher AMI / higher-paying units higher floors).
+
+## Success Criteria (from `docs/FIX_REQUIREMENTS.md`)
+- Only dedupe when outcomes are truly identical:
+  - same AMI band mix
+  - same rent outcome metrics used for client results
+  - same relevant mix/sqft outcome if part of outputs
+- Keep only one scenario per equivalence group.
+- Choose the kept scenario using placement tie-break:
+  - 40% units prefer lower floors
+  - higher AMI / higher paying units prefer higher floors
+- Must be surgical: do not change solver’s main scoring/constraints; apply as post-processing right before returning results.
+
+## Files To Change (target ≤ 3 total files for this fix)
+- `app.py`
+- `docs/CODEX_LEDGER.md` (after PR is opened)
+
+## Functions / Entrypoints To Change
+- `optimize_units()` (`/api/optimize`)
+
+## Proposed Patch (logic-level)
+- After strict scenarios + edge/top-up scenarios are fully assembled **and** rent totals are computed, dedupe scenarios by an “outcome signature”:
+  - normalized `metrics.band_mix` (band, units, net_sf)
+  - `rent_totals.net_monthly` + `rent_totals.net_annual`
+  - total SF / WAAMI (rounded) as an additional guard
+- For each equivalence group, pick the winner by “placement” score:
+  - reward higher `floor * assigned_ami` alignment
+  - reward higher `floor * monthly_rent` alignment (when present)
+  - penalize high floors for 40% band units
+  - deterministic tie-breaker (stable key ordering)
+- Keep the highest-priority scenario key for the group (`absolute_best` first, then `best_3_band`, `best_2_band`, `alternative`, etc.), but store the winning scenario object under that key and remove the others.
+- Be conservative: if required signature fields are missing (e.g., no rent schedule loaded → no `rent_totals`), skip dedupe.
+
+## Risk Pre‑Mortem
+- **Risk:** Over-dedupe due to float noise / rounding.
+  - **Mitigation:** Use rent totals (already rounded to 2 decimals) + band mix + total SF/WAAMI guard; only dedupe when all fields are present.
+- **Risk:** Returning fewer scenarios than expected (e.g., fewer than ~6).
+  - **Mitigation:** This is acceptable if duplicates were previously inflating count; record counts in edge test and keep top-up logic unchanged.
+- **Risk:** Accidentally removing `absolute_best` key.
+  - **Mitigation:** Always keep `absolute_best` as the “keeper key” when it’s part of a duplicate group.
+
+## Test Plan
+### Automated
+- `python -m pytest -q`
+
+### Edge check (count scenarios returned)
+- Run a local request via Flask test client and print:
+  - number of scenario keys returned
+  - which keys remain after dedupe
+  - confirm `absolute_best` is present
+
+## Rollback Plan
+- Revert the Fix-02 commit(s) on the branch and re-deploy the prior ready commit SHA from the ledger (Render auto-deploy is OFF).
+


### PR DESCRIPTION
Implements Fix-02 by de-duping outcome-identical scenarios returned from /api/optimize (same band mix + same net rent totals), selecting the kept scenario via a placement tie-break (40% lower floors; higher AMI/rent higher floors).\n\nNotes:\n- Post-processing only; does not change solver scoring/constraints.\n- Conservative: only de-dupes when rent_totals are present.\n\nTests:\n- python -m pytest -q (51 passed)\n\nEdge check:\n- /api/optimize via test client on Test.xlsx: scenario_count=5 and notes include 'De-duped 1 outcome-identical scenario(s) (Fix-02).'.