### PR TITLE
Fix-05: Manual Working Copy always-on + 2-way sync

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,147 @@
+# CODEX OPERATING PROTOCOL — NYC AMI Calculator
+
+You are working in an existing production repository. Your job is to implement small, isolated fixes without breaking established logic.
+
+## Repo + Base Branch (must be explicit)
+- Repo: martin10101/nyc-ami-calculator
+- Base branch for all fixes: perf/api-optimize-speed-2026-02-05
+
+- Codex must consult docs/FIX_REQUIREMENTS.md for acceptance criteria.
+
+## Golden Rules
+1) One fix per iteration. Do not combine fixes.
+2) Minimal diff. No refactors, renames, formatting sweeps, or dependency changes unless explicitly required.
+3) Preserve interfaces and Excel sheet structure unless the fix explicitly changes them.
+4) Do not change solver scoring/constraints unless the fix explicitly targets solver behavior.
+5) If you think you must touch >3 files, STOP and ask for approval.
+6) Never rely on ActiveSheet to locate MIH/UAP targets unless explicitly verified safe.
+
+## Required Workflow (every session)
+### Step 0 — Read the Ledger (required)
+Open docs/CODEX_LEDGER.md and identify:
+- the next unchecked fix in the queue,
+- the last completed fix,
+- any open risks or follow-ups.
+
+### Step 1 — Create a Branch
+Create a branch from the base branch:
+- fix/<ID>-<short-slug>
+
+### Step 2 — Produce a Task Card (before coding)
+Write a Task Card that includes:
+- Goal (2–4 bullets)
+- Success Criteria
+- Files to change (exact paths)
+- Functions/entrypoints to change
+- Proposed patch (logic-level description)
+- Risk pre-mortem (how this could break things + mitigations)
+- Test plan (exact steps)
+- Rollback plan
+
+Do not code until the Task Card is written.
+
+### Step 3 — Implement
+- Only implement what was proposed in the Task Card.
+- Keep changes localized.
+- Add/adjust tests only when lightweight and aligned with repo.
+
+### Step 4 — Verify
+- Run tests if possible.
+- If you cannot run tests, provide exact manual test steps and expected outputs.
+
+### Step 5 — GitHub Push + PR (required)
+After committing:
+1) Push the branch to origin.
+2) Open a draft PR targeting the base branch (perf/api-optimize-speed-2026-02-05).
+3) Put the Fix ID in the PR title (e.g., "Fix-04: Ribbon stays active").
+
+### Step 6 — Update Ledger (required)
+Update docs/CODEX_LEDGER.md with:
+- Repo + base branch
+- Work branch + commit SHA
+- PR number/link (or "no PR")
+- Files changed
+- Summary of changes
+- Tests run + results
+- Remaining notes/risks
+- Render deploy status (see below)
+Then STOP. Do not start the next fix.
+
+---
+
+## Render Deployment Rule (GitHub-backed service)
+We want deterministic deployments tied to a commit SHA, not branch-hopping.
+
+### Current setting (do not change)
+- Auto-deploy: OFF
+- Service ID: srv-d37n6her433s73et1bp0
+
+### Behavior required from Codex
+- Do NOT trigger deployments automatically.
+- Only record the ready-to-deploy commit SHA in docs/CODEX_LEDGER.md and tell the user which commit/PR to deploy.
+
+Preferred method (manual by user):
+- User deploys from Render dashboard when ready.
+Optional method (only if user provides deploy hook secret out-of-band):
+- Trigger deploy via Render deploy hook with `ref=<commit_sha>` (deploy specific commit).
+  - Note: deploying a specific commit may disable auto-deploys until reenabled. (Render docs)
+
+Render MCP note:
+- Render MCP currently does NOT support triggering deploys or modifying existing services (except env vars). Therefore do NOT rely on MCP for branch switching or deploy triggers. (Render docs)
+
+---
+
+## Known repo-specific findings (use these to guide safe fixes)
+### 1) Scenario apply uses cached DataSheet + AMI column
+- ApplyScenarioByKey(...) in excel-addin/src/AMI_Optix_ResultsWriter.bas calls GetDataSheet() and GetAMIColumn()
+- Those are cached in excel-addin/src/AMI_Optix_DataReader.bas (m_DataSheet, m_AMICol)
+- FindDataSheet() currently prefers ActiveSheet first — this can cause wrong targeting after UI interactions
+
+### 2) Ribbon dropdown currently activates sheets + shows MsgBox
+- Ribbon_SelectRentRoll(...) in excel-addin/src/AMI_Optix_Ribbon.bas uses .Activate and MsgBox
+- Avoid doing this in dropdown callbacks; it can cause context drift and ribbon focus issues
+
+### 3) Utilities already support variants in the UI + payload
+- excel-addin/forms/frmUtilities.frm includes variant codes
+- excel-addin/src/AMI_Optix_API.bas BuildAPIPayload sends electricity/cooking/heat/hot_water
+- “only 4 utilities” symptom is likely display/mapping, not capture
+
+---
+
+## Ledger Template (create if missing)
+(If docs/CODEX_LEDGER.md does not exist, create it using the template in this section.)
+
+# CODEX LEDGER
+
+## Repo + Base Branch
+- Repo: martin10101/nyc-ami-calculator
+- Base branch: perf/api-optimize-speed-2026-02-05
+
+## Render (optional but recommended)
+- Service name:
+- Environment:
+- Service ID: srv-d37n6her433s73et1bp0
+- Auto-deploy setting (On Commit / After CI / Off): OFF
+- Deploy hook URL: [REDACTED]
+
+## Fix Queue
+- [ ] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+- [ ] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+- [ ] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+- [ ] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+- [ ] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+- [ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+## Work Log
+### YYYY-MM-DD Fix-XX <title>
+- Repo:
+- Base branch:
+- Work branch:
+- Commit:
+- PR:
+- Files changed:
+- Summary:
+- Tests run + results:
+- Render deploy: (manual; ready commit SHA recorded)
+- Notes / risks:
+- Next:

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -36,7 +36,7 @@
 
 \- \[x] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
 
-\- \[ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+\- \[x] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
 
 
 
@@ -288,5 +288,53 @@
 
 \- Next: Fix-05
 
+
+\### 2026-02-18 Fix-05 Manual working-copy always-on + 2-way sync (MIH/UAP + rent roll)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/05-manual-working-copy-sync
+
+\- Commit: 77f9b75e7d2aa6dcf7b0cb2b281373094101aa26
+
+\- PR: \#13 https://github.com/martin10101/nyc-ami-calculator/pull/13 (draft)
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-05\_Manual\_working\_copy\_sync.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_AppEvents.cls
+
+&nbsp; - excel-addin/src/AMI\_Optix\_EventHooks.bas
+
+\- Summary:
+
+&nbsp; - Ribbon: removed the Manual “Live Sync” toggle; Manual Working Copy is always-on.
+
+&nbsp; - Live sync: on any AMI edit (Manual Working Copy or MIH/UAP AMI column), refresh the manual block via `/api/manual_calculate` so invalid mixes are allowed (tradeoffs shown) and rent roll calcs update.
+
+&nbsp; - Eventing: added stronger suppression to prevent re-entrant SheetChange loops; no auto-revert of edits.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings); edge optimize sanity: status 200, scenarios=4
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = 77f9b75e7d2aa6dcf7b0cb2b281373094101aa26
+
+\- Notes / risks:
+
+&nbsp; - Manual edits now persist even when invalid by program rules (intentional); tradeoffs are shown in the manual block.
+
+&nbsp; - Live refresh uses the Manual Calculate path; it temporarily activates AMI Scenarios internally but restores the user’s active sheet/selection with events disabled to avoid macro side effects.
+
+\- Next: (stop; queue complete)
 
 

--- a/docs/CODEX_LEDGER.md
+++ b/docs/CODEX_LEDGER.md
@@ -1,0 +1,292 @@
+\# CODEX LEDGER
+
+
+
+\## Repo + Base Branch
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+
+
+\## Render (fill once, keep updated)
+
+\- Service name:
+
+\- Environment:
+
+\- Service ID: srv-d37n6her433s73et1bp0
+
+\- Auto-deploy setting (On Commit / After CI / Off): OFF
+
+\- Deploy hook URL: \[REDACTED]
+
+
+
+\## Fix Queue
+
+\- \[x] Fix-01 DataReader stability + remove ribbon sheet activation (prevents wrong-sheet/AMI-col bugs)
+
+\- \[x] Fix-04 Ribbon stays active (no collapsing; no modal MsgBox in dropdown callbacks)
+
+\- \[x] Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- \[x] Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- \[x] Fix-02 Solver dedupe identical outcomes + placement tie-break (Python solver)
+
+\- \[ ] Fix-05 Manual working-copy always-on + two-way sync to MIH/UAP + rent roll + year (requires event modules / sheet code)
+
+
+
+\## Work Log
+
+\### 2026-02-17 Bootstrap
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: n/a
+
+\- Commit: n/a
+
+\- PR: n/a
+
+\- Files changed: CODEX.md, docs/CODEX\_LEDGER.md
+
+\- Summary: Added persistent operating protocol + ledger so Codex can resume work reliably across sessions and track repo/branch/PR and Render deploy readiness.
+
+\- Tests run + results: n/a
+
+\- Render deploy: n/a
+
+\- Notes / risks:
+
+&nbsp; - Auto-deploy is OFF; deployments are manual from Render dashboard. Record the “ready-to-deploy” commit SHA in the ledger.
+
+\- Next: Fix-01
+
+
+
+\### 2026-02-17 Fix-01 DataReader stability + remove ribbon sheet activation
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01-datareader-stability
+
+\- Commit: e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- PR: \#8 https://github.com/martin10101/nyc-ami-calculator/pull/8
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01\_DataReader\_stability.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_DataReader.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+\- Summary:
+
+&nbsp; - DataReader: FindDataSheet no longer treats incidental ActiveSheet as authoritative unless it's a known template/program sheet; prefers stable template names first to avoid wrong-sheet/AMI-column caching.
+
+&nbsp; - Ribbon: rent roll dropdown no longer activates worksheets or shows modal selection UI (stores selection only; DebugLog).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e370726c9d1b8c7b8627cbb2cb59cdf72783103e
+
+\- Notes / risks:
+
+&nbsp; - Workbooks with multiple unit-like tables may resolve to the first matching template-named sheet when the active sheet is not a known program sheet.
+
+\- Next: Fix-04
+
+
+
+\### 2026-02-18 Fix-04 Ribbon stays active (no collapsing)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/04-ribbon-stays-active
+
+\- Commit: f6792738125956226d4088d90239eba42cbfc8ff
+
+\- PR: \#9 https://github.com/martin10101/nyc-ami-calculator/pull/9
+
+\- Files changed:
+
+&nbsp; - docs/TASKCARD\_Fix-04\_Ribbon\_stays\_active.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+\- Summary:
+
+&nbsp; - Ribbon XML: add onLoad hook so VBA can capture `IRibbonUI`.
+
+&nbsp; - Ribbon callbacks: best-effort re-activate `tabAMIOptix` after `onAction` handlers so the AMI Optix tab remains selected after actions.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = f6792738125956226d4088d90239eba42cbfc8ff
+
+\- Notes / risks:
+
+&nbsp; - PR \#9 is stacked on PR \#8; merge PR \#8 first to reduce diff.
+
+\- Next: Fix-03
+
+
+
+\### 2026-02-18 Fix-03 Rent roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/03-rent-roll-year-selector
+
+\- Commit: e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- PR: \#10 https://github.com/martin10101/nyc-ami-calculator/pull/10
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-03\_RentRoll\_YEAR\_selector.md
+
+&nbsp; - excel-addin/customUI/customUI14.xml
+
+&nbsp; - excel-addin/src/AMI\_Optix\_Ribbon.bas
+
+&nbsp; - excel-addin/src/AMI\_Optix\_API.bas
+
+\- Summary:
+
+&nbsp; - Ribbon: add **Rent Roll Year** dropdown (2022â€“2026, default 2025) + **Manage Rent Roll Yearsâ€¦** upload/replace action.
+
+&nbsp; - Local persistence: store selected year calculators under `%APPDATA%\\AMI_Optix\\RentRollYears\\<year>\\`.
+
+&nbsp; - API storage: upload selected year calculator to `/api/rent-calculators/upload` and activate via `/api/rent-calculators/activate`.
+
+&nbsp; - Enforcement: API calls (optimize/evaluate/manual\_calculate) ensure the selected year is active before running.
+
+&nbsp; - Warning: best-effort mismatch warning if workbook appears to declare a different year than the selection (OK continues; not blocking).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = e07ecb0ecb0623622d7311996e56911c8baba379
+
+\- Notes / risks:
+
+&nbsp; - Rent calculator activation is server-global; switching years affects other clients using the same API service.
+
+&nbsp; - Declared-year detection is best-effort; some templates may not yield a detectable year (no warning shown).
+
+\- Next: Fix-01b
+
+
+\### 2026-02-18 Fix-01b Utilities variant breakdown (top-of-sheet; do not collapse variant labels)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/01b-utilities-variant-breakdown
+
+\- Commit: 954abcfd0b957258089f54b4d5e1f7bbfc2fd73a
+
+\- PR: \#11 https://github.com/martin10101/nyc-ami-calculator/pull/11
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-01b\_Utilities\_variant\_breakdown.md
+
+&nbsp; - excel-addin/src/AMI\_Optix\_ResultsWriter.bas
+
+\- Summary:
+
+&nbsp; - AMI Scenarios (top-of-sheet): utilities block now shows the exact rent roll guideline variant labels per category (no collapsed 'Gas/Oil/Electric' labels).
+
+&nbsp; - No scenario grid/per-scenario column changes.
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = 954abcfd0b957258089f54b4d5e1f7bbfc2fd73a
+
+\- Notes / risks:
+
+&nbsp; - Heat labels include guideline footnote markers ('...ccASHP)1', 'Other2'), matching the rent calculator workbook.
+
+\- Next: Fix-02
+
+
+\### 2026-02-18 Fix-02 Solver dedupe identical outcomes + placement tie-break (Python)
+
+\- Repo: martin10101/nyc-ami-calculator
+
+\- Base branch: perf/api-optimize-speed-2026-02-05
+
+\- Work branch: fix/02-solver-outcome-dedupe
+
+\- Commit: acac3a76ca5760f5f3ca8fdf09cb3fd54bbfcbb8
+
+\- PR: \#12 https://github.com/martin10101/nyc-ami-calculator/pull/12
+
+\- Files changed:
+
+&nbsp; - CODEX.md
+
+&nbsp; - docs/CODEX\_LEDGER.md
+
+&nbsp; - docs/FIX\_REQUIREMENTS.md
+
+&nbsp; - docs/TASKCARD\_Fix-02\_Solver\_outcome\_dedupe.md
+
+&nbsp; - app.py
+
+\- Summary:
+
+&nbsp; - API (/api/optimize): post-process returned scenarios to remove outcome-identical duplicates (same band mix + same net rent totals), keeping the best floor placement (40% lower floors; higher AMI/rent higher floors).
+
+\- Tests run + results: python -m pytest -q (51 passed, 13 warnings)
+
+\- Render deploy: manual; auto-deploy OFF; ready-to-deploy commit SHA = acac3a76ca5760f5f3ca8fdf09cb3fd54bbfcbb8
+
+\- Notes / risks:
+
+&nbsp; - Dedupe is conservative and only runs when rent totals are available (rent calculator loaded).
+
+&nbsp; - Edge check: Test.xlsx optimize returned 5 scenarios and reported 1 duplicate removed (Fix-02 note).
+
+\- Next: Fix-05
+
+
+

--- a/docs/FIX_REQUIREMENTS.md
+++ b/docs/FIX_REQUIREMENTS.md
@@ -1,0 +1,280 @@
+\# FIX REQUIREMENTS — NYC AMI Calculator
+
+
+
+Base branch: perf/api-optimize-speed-2026-02-05  
+
+Repo: martin10101/nyc-ami-calculator
+
+
+
+This document defines the expected behavior for each fix.  
+
+Codex must not reinterpret these requirements.
+
+
+
+---
+
+
+
+\## Fix-01 — DataReader stability + remove ribbon sheet activation
+
+\### Problem
+
+Scenario application and other actions sometimes write to the wrong sheet/column after UI interactions because DataReader binds to ActiveSheet and ribbon callbacks activate sheets.
+
+
+
+\### Requirements
+
+\- DataReader must locate MIH/UAP target sheet and AMI column using stable anchors.
+
+\- FindDataSheet must NOT prefer ActiveSheet unless it is explicitly validated to be the MIH/UAP data sheet.
+
+\- Ribbon dropdown callbacks must NOT `.Activate` worksheets and must not use modal MsgBoxes for normal selection.
+
+\- Scenario apply must work even after any manual clears / switching sheets / using dropdowns.
+
+
+
+\### Must NOT change
+
+\- Excel sheet structure or headers.
+
+\- Solver logic.
+
+\- Scenario grid layout.
+
+
+
+\### Test (manual)
+
+\- Apply scenario #2 repeatedly while switching sheets; AMI writes always land in correct column.
+
+\- After using rent roll dropdown, apply scenario; still correct.
+
+
+
+---
+
+
+
+\## Fix-04 — Ribbon stays active (no collapsing)
+
+\### Problem
+
+AMI ribbon tab collapses/disappears after interacting with worksheet, forcing user to click AMI tab again.
+
+
+
+\### Requirements
+
+\- Selecting AMI ribbon tab should behave like normal Excel tabs: it stays active while user works.
+
+\- Dropdown selection and button clicks must not cause the tab to collapse.
+
+\- Must work consistently for all ribbon buttons (MIH + UAP).
+
+
+
+\### Must NOT change
+
+\- Any calculations.
+
+\- Any scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Open AMI tab → click a control → click worksheet cells → AMI tab remains selected.
+
+\- Repeat with dropdown controls and MIH/UAP buttons.
+
+
+
+---
+
+
+
+\## Fix-03 — Rent Roll YEAR selector + Manage uploads + mismatch warning (MIH + UAP)
+
+\### Requirements
+
+\- Add ribbon year selector: 2022, 2023, 2024, 2025, 2026 (default 2025).
+
+\- Add a “Manage Rent Roll Years…” UI (form preferred) to upload/replace year files.
+
+\- Uploaded year files must persist locally (suggested: %APPDATA%\\\\AMI\_Optix\\\\RentRollYears\\\\<year>\\\\).
+
+\- Upload action should also transfer the file once to the API for storage (exact server storage mechanism can be decided, but client must not need to send files manually outside Excel).
+
+\- Selected year must override any year implied inside the active workbook’s rent roll page.
+
+\- If workbook “declared year” != selected year, show warning (OK to continue; not blocking).
+
+\- Every MIH/UAP action that uses rent roll/utilities must use the selected year.
+
+
+
+\### Must NOT change
+
+\- Scenario grid structure.
+
+\- Solver logic (except reading different year data).
+
+\- Existing rent roll math except to swap source year data.
+
+
+
+\### Test (manual)
+
+\- Upload 2022 and 2024.
+
+\- Select 2022 → run calc → confirm it uses 2022 tables.
+
+\- Workbook declares 2025 but dropdown is 2022 → warning appears; OK continues.
+
+
+
+---
+
+
+
+\## Fix-01b — Utilities variant breakdown (top-of-sheet; do not collapse)
+
+\### Problem
+
+Utilities are displayed too generically; the sheet should show which specific variants are used.
+
+
+
+\### Requirements
+
+\- Do NOT alter scenario grid structure or per-scenario columns.
+
+\- Add a top-of-sheet utility breakdown block that shows selected variants (exact names/labels as in rent roll guidelines).
+
+\- Ensure rent roll net rent uses the correct total utility allowance based on selected variants.
+
+\- Utilities are already variant-aware in the UI + payload (electricity/cooking/heat/hot\_water). Ensure display and mapping do not collapse variants incorrectly.
+
+
+
+\### Must NOT change
+
+\- Existing payload keys unless confirmed needed.
+
+\- Scenario output structure.
+
+
+
+\### Test (manual)
+
+\- Pick a non-default heat/hot water variant → run → top-of-sheet shows exact variant and allowance matches.
+
+
+
+---
+
+
+
+\## Fix-02 — Solver dedupe identical outcomes + placement tie-break (Python)
+
+\### Problem
+
+Solver returns “duplicate-looking” scenarios that are outcome-identical but differ only by unit swaps.
+
+
+
+\### Requirements
+
+\- Only dedupe when outcomes are truly identical:
+
+&nbsp; - same AMI band mix
+
+&nbsp; - same rent outcome metrics used for client results
+
+&nbsp; - same relevant mix/sqft outcome if part of outputs
+
+\- Keep only one scenario per equivalence group.
+
+\- Choose the kept scenario using placement tie-break:
+
+&nbsp; - 40% units prefer lower floors
+
+&nbsp; - higher AMI / higher paying units prefer higher floors
+
+\- Must be surgical: do not change solver’s main scoring/constraints; apply as post-processing right before returning results.
+
+
+
+\### Test (manual or unit test)
+
+\- Two identical-outcome scenarios differing only by floor swap → only one returned, preferred placement chosen.
+
+\- Two scenarios with same AMI mix but different rent totals → BOTH remain.
+
+
+
+---
+
+
+
+\## Fix-05 — Manual working-copy always-on + 2-way sync (MIH/UAP + rent roll + year)
+
+\### Goal
+
+Remove the manual scenario on/off toggle completely and make the “manual scenario” the always-present editable working copy.
+
+
+
+\### Requirements
+
+\- There is always an editable Manual Working Copy.
+
+\- Stored solver scenarios (1..N) remain immutable.
+
+\- Selecting scenario #k copies it into Manual Working Copy and applies it to MIH/UAP, but does not change scenario #k snapshot.
+
+\- Edits to Manual Working Copy:
+
+&nbsp; - are allowed even if violating rules (warn but allow override)
+
+&nbsp; - immediately update MIH/UAP AMI column at matching unit
+
+&nbsp; - immediately update rent roll calculations (including using selected rent roll YEAR)
+
+\- Edits to MIH/UAP AMI column:
+
+&nbsp; - immediately update Manual Working Copy
+
+&nbsp; - update rent roll calculations
+
+\- Must include re-entrancy guard to prevent infinite change-event loops.
+
+
+
+\### Must NOT change
+
+\- Scenario snapshots for 1..N.
+
+\- Solver logic.
+
+\- Scenario grid structure.
+
+
+
+\### Test (manual)
+
+\- Select scenario #2 → manual reflects it; scenario #2 snapshot unchanged.
+
+\- Edit manual unit AMI → MIH/UAP updates instantly; rent roll updates.
+
+\- Edit MIH/UAP AMI cell → manual updates; rent roll updates.
+
+\- Repeat after switching sheets and switching selected rent roll year.
+
+
+

--- a/docs/TASKCARD_Fix-05_Manual_working_copy_sync.md
+++ b/docs/TASKCARD_Fix-05_Manual_working_copy_sync.md
@@ -1,0 +1,77 @@
+# Task Card — Fix-05: Manual Working Copy always-on + 2-way sync
+
+Date: 2026-02-18  
+Repo: martin10101/nyc-ami-calculator  
+Base branch: perf/api-optimize-speed-2026-02-05  
+Work branch: fix/05-manual-working-copy-sync
+
+## Goal
+- Remove the manual scenario ON/OFF (live sync) toggle; manual working copy is always present/editable.
+- Keep solver scenarios (1..N) immutable; selecting scenario #k copies it into Manual Working Copy and applies to MIH/UAP without mutating the snapshot.
+- Allow Manual Working Copy edits even when rule-invalid (warn but allow override).
+- Ensure 2-way sync between Manual Working Copy and MIH/UAP AMI column, and refresh rent roll calcs on either edit.
+
+## Success Criteria (docs/FIX_REQUIREMENTS.md)
+- Selecting scenario #2 updates manual working copy; scenario #2 snapshot remains unchanged.
+- Editing manual unit AMI updates MIH/UAP AMI instantly and refreshes rent roll.
+- Editing MIH/UAP AMI cell updates manual working copy and refreshes rent roll.
+- No infinite change-event loops; behavior remains stable after switching sheets and changing rent roll year (if present).
+
+## Files to change (keep minimal)
+- `excel-addin/customUI/customUI14.xml`
+- `excel-addin/src/AMI_Optix_EventHooks.bas`
+- `excel-addin/src/AMI_Optix_AppEvents.cls`
+
+## Functions / Entrypoints to change
+- Ribbon UI: remove references to `Ribbon_ToggleLiveSync` / `Ribbon_GetLiveSync` by deleting the toggle control from XML.
+- `excel-addin/src/AMI_Optix_EventHooks.bas`
+  - `GetLiveSyncEnabled()`
+  - `SetLiveSyncEnabled(enabled As Boolean)`
+- `excel-addin/src/AMI_Optix_AppEvents.cls`
+  - `App_SheetChange(...)`
+  - Manual working copy handlers (single-cell + range edits)
+  - MIH/UAP AMI edit handler
+
+## Proposed Patch (logic-level)
+- **Always-on manual working copy**
+  - Remove the ribbon toggle control from `customUI14.xml`.
+  - Make `GetLiveSyncEnabled()` always return `True` and make `SetLiveSyncEnabled(...)` a no-op (or keep state but never disable).
+- **Relaxed manual edits (warn, don’t revert)**
+  - In `AMI_Optix_AppEvents.cls`, replace the “evaluate + revert on invalid” behavior for Manual Working Copy edits with a “manual_calculate + refresh” path:
+    - Apply the edited AMI value to the corresponding MIH/UAP AMI cell (and vice versa).
+    - Call `/api/manual_calculate` (quietly) to compute rent totals + diagnostics without enforcing constraints.
+    - Write diagnostics/tradeoffs into the existing manual/tradeoffs area (no modal MsgBox; no revert).
+- **Re-entrancy guard**
+  - Ensure all writes triggered by SheetChange run under `g_AMIOptixSuppressEvents` + `Application.EnableEvents = False` to prevent loops.
+- **Must NOT touch**
+  - Scenario snapshot grid (solver scenarios 1..N), solver logic, or scenario keys.
+
+## Risk pre-mortem + mitigations
+- **Infinite SheetChange loops** if we write back into the edited range.
+  - Mitigation: strict guard + write suppression; early-exit if `g_AMIOptixSuppressEvents` or `Application.EnableEvents=False`.
+- **Wrong sheet/AMI column** targeted during sync.
+  - Mitigation: use existing anchored “data sheet” helpers (no `ActiveSheet` assumptions) and keep all lookups unchanged.
+- **Performance regression** from calling API on every edit.
+  - Mitigation: only call manual_calculate for edits inside manual working copy or AMI column; avoid calling for unrelated edits.
+- **Accidental scenario snapshot mutation**.
+  - Mitigation: only write to Manual Working Copy region and MIH/UAP AMI column; never write into scenario snapshot grid.
+
+## Test Plan
+### Automated (CLI)
+- `python -m pytest -q`
+- Edge scenario count sanity (API should still return up to target scenarios; record count):
+  - `python -c "from app import app; c=app.test_client(); p={'program':'UAP','utilities':{'electricity':'na','cooking':'na','heat':'na','hot_water':'na'},'units':[{'unit_id':'L1','bedrooms':1,'net_sf':200,'floor':1,'balcony':False},{'unit_id':'L2','bedrooms':1,'net_sf':200,'floor':1,'balcony':False},{'unit_id':'H1','bedrooms':2,'net_sf':400,'floor':6,'balcony':True},{'unit_id':'H2','bedrooms':2,'net_sf':400,'floor':6,'balcony':True},{'unit_id':'M1','bedrooms':2,'net_sf':400,'floor':3,'balcony':False},{'unit_id':'M2','bedrooms':2,'net_sf':400,'floor':3,'balcony':False}]}; r=c.post('/api/optimize',json=p); d=r.get_json(); print('status',r.status_code,'scenarios',len((d or {}).get('scenarios') or {}))\"`
+
+### Manual (Excel)
+- Select scenario #2 → Manual Working Copy updates; scenario #2 snapshot unchanged.
+- Edit a Manual Working Copy AMI value to an invalid mix:
+  - It stays (no revert), but a warning/tradeoffs are shown somewhere in the manual/tradeoffs area.
+  - MIH/UAP AMI column updates immediately; rent roll calcs refresh.
+- Edit MIH/UAP AMI column cell → Manual Working Copy updates immediately; rent roll calcs refresh.
+- Repeat after switching worksheets and changing selected rent roll year (if available).
+
+## Rollback Plan
+- `git revert <fix_commit_sha>` (or reset branch) to restore:
+  - live sync toggle UI + persisted enabled/disabled state
+  - strict evaluate+revert behavior for manual edits
+

--- a/excel-addin/customUI/customUI14.xml
+++ b/excel-addin/customUI/customUI14.xml
@@ -74,13 +74,6 @@
                   supertip="Open the log folder."/>
         </group>
         <group id="grpManual" label="Manual">
-          <toggleButton id="tglLiveSync"
-                        label="Live Sync"
-                        size="normal"
-                        imageMso="RefreshAll"
-                        getPressed="Ribbon_GetLiveSync"
-                        onAction="Ribbon_ToggleLiveSync"
-                        supertip="When ON, Scenario Manual auto-syncs with AMI edits. Turn OFF to clear the manual block and AMI column for custom inputs."/>
           <button id="btnManualCalculate"
                   label="Manual Calculate"
                   size="normal"

--- a/excel-addin/src/AMI_Optix_AppEvents.cls
+++ b/excel-addin/src/AMI_Optix_AppEvents.cls
@@ -112,56 +112,101 @@ Private Function DetectProgramFromWorkbook() As String
     End If
 End Function
 
+Private Sub RefreshManualWorkingCopyFromProgramInputs(programNorm As String, contextSheet As Worksheet, contextTarget As Range)
+    ' Fix-05: "Manual Working Copy" is always present and should refresh after any AMI edit,
+    ' even if the current assignment violates rules (warn via tradeoffs; do not revert).
+    Dim prevEnableEvents As Boolean
+    Dim prevScreenUpdating As Boolean
+    Dim prevSuppress As Boolean
+    prevEnableEvents = Application.EnableEvents
+    prevScreenUpdating = Application.ScreenUpdating
+    prevSuppress = g_AMIOptixSuppressEvents
+
+    On Error GoTo SafeExit
+
+    If Not HasAPIKey() Then GoTo SafeExit
+    If ActiveWorkbook Is Nothing Then GoTo SafeExit
+
+    g_AMIOptixSuppressEvents = True
+    Application.EnableEvents = False
+    Application.ScreenUpdating = False
+
+    Call ManualCalculateScenario(programNorm)
+
+    ' ManualCalculateScenario activates AMI Scenarios at the end; restore user context.
+    If Not contextSheet Is Nothing Then
+        contextSheet.Activate
+        If Not contextTarget Is Nothing Then
+            contextTarget.Cells(1, 1).Select
+        End If
+    End If
+
+SafeExit:
+    On Error Resume Next
+    Application.ScreenUpdating = prevScreenUpdating
+    Application.EnableEvents = prevEnableEvents
+    g_AMIOptixSuppressEvents = prevSuppress
+End Sub
+
+Private Sub ApplyManualAmiChangesAndRefresh(programNorm As String, changes As Object, contextSheet As Worksheet, contextTarget As Range)
+    ' Applies unit_id -> AMI updates to the program sheet, then refreshes the manual working copy.
+    Dim prevEnableEvents As Boolean
+    Dim prevScreenUpdating As Boolean
+    Dim prevSuppress As Boolean
+    prevEnableEvents = Application.EnableEvents
+    prevScreenUpdating = Application.ScreenUpdating
+    prevSuppress = g_AMIOptixSuppressEvents
+
+    On Error GoTo SafeExit
+
+    If changes Is Nothing Then GoTo SafeExit
+    If changes.Count = 0 Then GoTo SafeExit
+    If Not HasAPIKey() Then GoTo SafeExit
+    If ActiveWorkbook Is Nothing Then GoTo SafeExit
+
+    g_AMIOptixSuppressEvents = True
+    Application.EnableEvents = False
+    Application.ScreenUpdating = False
+
+    Dim dataWs As Worksheet
+    Set dataWs = GetProgramDataSheet(programNorm)
+
+    If Not dataWs Is Nothing Then
+        Dim key As Variant
+        For Each key In changes.Keys
+            ApplyAmiToWorksheet dataWs, CStr(key), CDbl(changes(key))
+        Next key
+    End If
+
+    Call ManualCalculateScenario(programNorm)
+
+    ' ManualCalculateScenario activates AMI Scenarios at the end; restore user context.
+    If Not contextSheet Is Nothing Then
+        contextSheet.Activate
+        If Not contextTarget Is Nothing Then
+            contextTarget.Cells(1, 1).Select
+        End If
+    End If
+
+SafeExit:
+    On Error Resume Next
+    Application.ScreenUpdating = prevScreenUpdating
+    Application.EnableEvents = prevEnableEvents
+    g_AMIOptixSuppressEvents = prevSuppress
+End Sub
+
 Private Sub HandleDataSheetAmiChange(ws As Worksheet, target As Range, programNorm As String)
     ' Sync: when the user edits the AMI column on the data sheet, update the Scenario Manual block.
     On Error GoTo SafeExit
 
-    g_AMIOptixSuppressEvents = True
+    Call RefreshManualWorkingCopyFromProgramInputs(programNorm, ws, target)
 
-    Dim oldValue As Variant
-    Dim hasOldValue As Boolean
-    hasOldValue = (UCase(m_LastSelectionSheet) = UCase(ws.Name) And m_LastSelectionAddress = target.Address(False, False))
-    If hasOldValue Then oldValue = m_LastSelectionValue
-
-    Dim ok As Boolean
-    ok = UpdateManualScenario(False, programNorm)
-
-    If (Not ok) And g_AMIOptixLastManualScenarioInvalid Then
-        ' Revert the invalid edit without relying on Application.Undo (unreliable in event handlers).
-        If hasOldValue Then
-            Application.EnableEvents = False
-            target.Value = oldValue
-
-            ' Best-effort: keep AMI column formatted as percent.
-            Dim headerRow As Long
-            Dim amiCol As Long
-            headerRow = FindHeaderRow(ws)
-            amiCol = 0
-            If headerRow > 0 Then amiCol = FindAMIColumn(ws, headerRow)
-            If amiCol > 0 Then
-                Dim amiCells As Range
-                Set amiCells = Intersect(target, ws.Columns(amiCol))
-                If Not amiCells Is Nothing Then
-                    amiCells.NumberFormat = "0%"
-                End If
-            End If
-            Application.EnableEvents = True
-
-            ' Refresh the manual block to match the reverted values.
-            Call UpdateManualScenario(False, programNorm)
-
-            ' Keep last selection cache consistent for subsequent edits.
-            m_LastSelectionValue = oldValue
-        End If
-    ElseIf ok Then
-        ' Keep last selection cache consistent for subsequent edits.
-        m_LastSelectionSheet = CStr(ws.Name)
-        m_LastSelectionAddress = target.Address(False, False)
-        m_LastSelectionValue = target.Value
-    End If
+    ' Keep last selection cache consistent for subsequent edits.
+    m_LastSelectionSheet = CStr(ws.Name)
+    m_LastSelectionAddress = target.Address(False, False)
+    m_LastSelectionValue = target.Value
 
 SafeExit:
-    g_AMIOptixSuppressEvents = False
 End Sub
 
 Private Function ChangeIsInAMIColumn(ws As Worksheet, target As Range) As Boolean
@@ -231,118 +276,17 @@ Private Sub HandleManualScenarioEdit(ws As Worksheet, target As Range)
     newAmi = ParseAmiValue(target.Value)
     If newAmi <= 0 Then Exit Sub
 
-    ' Validate via /api/evaluate before applying to the data sheet.
-    Dim prevSheet As Worksheet
-    Set prevSheet = ActiveSheet
-
     Dim programNorm As String
     programNorm = DetectProgramFromWorkbook()
 
-    Dim mihOption As String
-    Dim mihResidentialSF As Double
-    Dim mihMaxBandPercent As Long
-    mihOption = ""
-    mihResidentialSF = 0
-    mihMaxBandPercent = 0
-    If programNorm = "MIH" Then
-        If Not TryReadMIHInputs(mihOption, mihResidentialSF, mihMaxBandPercent) Then Exit Sub
-    End If
+    Dim changes As Object
+    Set changes = CreateObject("Scripting.Dictionary") ' unit_id -> newAmi
+    changes(unitId) = newAmi
 
-    Dim dataWs As Worksheet
-    Set dataWs = Nothing
-    On Error Resume Next
-    If programNorm = "MIH" Then
-        ' Prefer MIH sheet first (per client request), fallback only if needed.
-        Set dataWs = ActiveWorkbook.Worksheets("MIH")
-        If dataWs Is Nothing Then Set dataWs = ActiveWorkbook.Worksheets("RentRoll")
-    Else
-        Set dataWs = ActiveWorkbook.Worksheets("UAP")
-    End If
-    On Error GoTo Fail
-    If dataWs Is Nothing Then Exit Sub
-
-    dataWs.Activate
-    Dim units As Collection
-    Set units = ReadUnitData()
-    prevSheet.Activate
-
-    If units Is Nothing Or units.Count = 0 Then Exit Sub
-
-    Dim i As Long
-    Dim u As Object
-    For i = 1 To units.Count
-        Set u = units(i)
-        If CStr(u("unit_id")) = unitId Then
-            u("client_ami") = newAmi
-            Exit For
-        End If
-    Next i
-
-    Dim utilities As Object
-    Set utilities = GetUtilitySelectionsForProgram(programNorm)
-
-    Dim payload As String
-    payload = BuildEvaluatePayloadV2(units, utilities, programNorm, mihOption, mihResidentialSF, mihMaxBandPercent)
-
-    Dim response As String
-    response = CallEvaluateAPI(payload)
-    If response = "" Then Exit Sub
-
-    Dim evalResult As Object
-    Set evalResult = ParseJSON(response)
-    If evalResult Is Nothing Then Exit Sub
-
-    If evalResult.Exists("success") Then
-        If evalResult("success") = False Then
-            Dim oldValue As Variant
-            Dim hasOldValue As Boolean
-            hasOldValue = (UCase(m_LastSelectionSheet) = UCase(ws.Name) And m_LastSelectionAddress = target.Address(False, False))
-            If hasOldValue Then oldValue = m_LastSelectionValue
-
-            Dim fallbackValue As Variant
-            Dim hasFallback As Boolean
-            hasFallback = False
-            If Not hasOldValue Then
-                hasFallback = TryGetDataSheetAmiValue(programNorm, unitId, fallbackValue)
-            End If
-
-            g_AMIOptixSuppressEvents = True
-            Application.EnableEvents = False
-            If hasOldValue Then
-                target.Value = oldValue
-                If IsNumeric(oldValue) Then target.NumberFormat = "0%"
-                m_LastSelectionValue = oldValue
-            ElseIf hasFallback Then
-                target.Value = fallbackValue
-                If IsNumeric(fallbackValue) Then target.NumberFormat = "0%"
-                m_LastSelectionValue = fallbackValue
-            End If
-            Application.EnableEvents = True
-            g_AMIOptixSuppressEvents = False
-
-            Dim msg As String
-            msg = "Invalid manual change. Reverted." & vbCrLf & vbCrLf
-            If evalResult.Exists("errors") Then
-                Dim errs As Object
-                Set errs = evalResult("errors")
-                For i = 1 To errs.Count
-                    msg = msg & "- " & errs(i) & vbCrLf
-                Next i
-            End If
-            MsgBox msg, vbExclamation, "AMI Optix"
-            Exit Sub
-        End If
-    End If
-
-    ' Apply to the data sheet (last-edit wins) and refresh manual scenario block.
-    g_AMIOptixSuppressEvents = True
-    ApplyAmiToDataSheet programNorm, unitId, newAmi
-    Call UpdateManualScenario(False, programNorm)
-    g_AMIOptixSuppressEvents = False
+    Call ApplyManualAmiChangesAndRefresh(programNorm, changes, ws, target)
     Exit Sub
 
 Fail:
-    g_AMIOptixSuppressEvents = False
 End Sub
 
 Private Sub HandleManualScenarioEditRange(ws As Worksheet, target As Range)
@@ -375,9 +319,6 @@ Private Sub HandleManualScenarioEditRange(ws As Worksheet, target As Range)
     Dim changes As Object
     Set changes = CreateObject("Scripting.Dictionary") ' unit_id -> newAmi
 
-    Dim changeRows As Object
-    Set changeRows = CreateObject("Scripting.Dictionary") ' unit_id -> row
-
     Dim c As Range
     For Each c In inTable.Cells
         Dim unitId As String
@@ -389,140 +330,20 @@ Private Sub HandleManualScenarioEditRange(ws As Worksheet, target As Range)
         If newAmi <= 0 Then GoTo NextCell
 
         changes(unitId) = newAmi
-        changeRows(unitId) = CLng(c.row)
 
 NextCell:
     Next c
 
     If changes.Count = 0 Then Exit Sub
 
-    Dim prevSheet As Worksheet
-    Set prevSheet = ActiveSheet
-
     Dim programNorm As String
     programNorm = DetectProgramFromWorkbook()
 
-    Dim mihOption As String
-    Dim mihResidentialSF As Double
-    Dim mihMaxBandPercent As Long
-    mihOption = ""
-    mihResidentialSF = 0
-    mihMaxBandPercent = 0
-    If programNorm = "MIH" Then
-        If Not TryReadMIHInputs(mihOption, mihResidentialSF, mihMaxBandPercent) Then Exit Sub
-    End If
-
-    ' Activate a likely data sheet so ReadUnitData doesn't accidentally read from AMI Scenarios.
-    Dim dataWs As Worksheet
-    Set dataWs = Nothing
-    On Error Resume Next
-    If programNorm = "MIH" Then
-        ' Prefer MIH sheet first (per client request), fallback only if needed.
-        Set dataWs = ActiveWorkbook.Worksheets("MIH")
-        If dataWs Is Nothing Then Set dataWs = ActiveWorkbook.Worksheets("RentRoll")
-        If dataWs Is Nothing Then Set dataWs = ActiveWorkbook.Worksheets("UAP")
-        If dataWs Is Nothing Then Set dataWs = ActiveWorkbook.Worksheets("PROJECT WORKSHEET")
-    Else
-        Set dataWs = ActiveWorkbook.Worksheets("UAP")
-    End If
-    On Error GoTo Fail
-    If Not dataWs Is Nothing Then dataWs.Activate
-
-    Dim units As Collection
-    Set units = ReadUnitData()
-
-    ' Capture which sheet actually contained the unit table.
-    On Error Resume Next
-    Set dataWs = GetDataSheet()
-    On Error GoTo Fail
-
-    prevSheet.Activate
-
-    If units Is Nothing Or units.Count = 0 Then Exit Sub
-
-    Dim i As Long
-    Dim u As Object
-    For i = 1 To units.Count
-        Set u = units(i)
-        Dim uid As String
-        uid = CStr(u("unit_id"))
-        If changes.Exists(uid) Then
-            u("client_ami") = CDbl(changes(uid))
-        End If
-    Next i
-
-    Dim utilities As Object
-    Set utilities = GetUtilitySelectionsForProgram(programNorm)
-
-    Dim payload As String
-    payload = BuildEvaluatePayloadV2(units, utilities, programNorm, mihOption, mihResidentialSF, mihMaxBandPercent)
-
-    Dim response As String
-    response = CallEvaluateAPI(payload)
-    If response = "" Then Exit Sub
-
-    Dim evalResult As Object
-    Set evalResult = ParseJSON(response)
-    If evalResult Is Nothing Then Exit Sub
-
-    If evalResult.Exists("success") Then
-        If evalResult("success") = False Then
-            ' Revert all changed cells to the current data sheet value (best-effort).
-            g_AMIOptixSuppressEvents = True
-            Application.EnableEvents = False
-
-            Dim key As Variant
-            For Each key In changes.Keys
-                Dim fallbackValue As Variant
-                Dim hasFallback As Boolean
-                hasFallback = False
-                If Not dataWs Is Nothing Then
-                    hasFallback = TryGetAmiValueFromWorksheet(dataWs, CStr(key), fallbackValue)
-                End If
-                If hasFallback Then
-                    ws.Cells(CLng(changeRows(key)), amiCol).Value = fallbackValue
-                    ws.Cells(CLng(changeRows(key)), amiCol).NumberFormat = "0%"
-                End If
-            Next key
-
-            Application.EnableEvents = True
-            g_AMIOptixSuppressEvents = False
-
-            Dim msg As String
-            msg = "Invalid manual change. Reverted." & vbCrLf & vbCrLf
-            If evalResult.Exists("errors") Then
-                Dim errs As Object
-                Set errs = evalResult("errors")
-                For i = 1 To errs.Count
-                    msg = msg & "- " & errs(i) & vbCrLf
-                Next i
-            End If
-            MsgBox msg, vbExclamation, "AMI Optix"
-            Exit Sub
-        End If
-    End If
-
-    ' Apply all changes to the data sheet and refresh the manual scenario.
-    g_AMIOptixSuppressEvents = True
-    Application.EnableEvents = False
-
-    If Not dataWs Is Nothing Then
-        Dim k2 As Variant
-        For Each k2 In changes.Keys
-            ApplyAmiToWorksheet dataWs, CStr(k2), CDbl(changes(k2))
-        Next k2
-    End If
-
-    Application.EnableEvents = True
-    g_AMIOptixSuppressEvents = False
-
-    Call UpdateManualScenario(False, programNorm)
+    Call ApplyManualAmiChangesAndRefresh(programNorm, changes, ws, target)
     Exit Sub
 
 Fail:
-    g_AMIOptixSuppressEvents = False
     On Error Resume Next
-    Application.EnableEvents = True
 End Sub
 
 Private Function TryGetDataSheetAmiValue(programNorm As String, unitId As String, ByRef amiValue As Variant) As Boolean
@@ -708,8 +529,8 @@ Fail:
 End Function
 
 Private Function FindManualTableHeaderRow(ws As Worksheet) As Long
-    ' Finds the header row for the "Scenario Manual (Live Sync)" unit table.
-    ' We intentionally anchor on the "SCENARIO MANUAL (LIVE SYNC)" label to avoid
+    ' Finds the header row for the Manual Working Copy unit table.
+    ' We intentionally anchor on the manual-block label to avoid
     ' accidentally matching the scenario tables lower on the sheet.
     Dim r As Long
     Dim labelRow As Long
@@ -719,7 +540,7 @@ Private Function FindManualTableHeaderRow(ws As Worksheet) As Long
         ' Allow suffixes like "- CURRENT: ABSOLUTE BEST".
         Dim label As String
         label = UCase$(Trim$(CStr(ws.Cells(r, 1).Value)))
-        If Left$(label, Len("SCENARIO MANUAL (LIVE SYNC)")) = "SCENARIO MANUAL (LIVE SYNC)" Then
+        If Left$(label, Len("SCENARIO MANUAL")) = "SCENARIO MANUAL" Or Left$(label, Len("MANUAL WORKING COPY")) = "MANUAL WORKING COPY" Then
             labelRow = r
             Exit For
         End If

--- a/excel-addin/src/AMI_Optix_EventHooks.bas
+++ b/excel-addin/src/AMI_Optix_EventHooks.bas
@@ -17,22 +17,21 @@ Private m_EnsureVisibleAt As Date
 Public Sub EnsureLiveSyncInitialized()
     If m_LiveSyncInitialized Then Exit Sub
 
-    Dim v As String
-    v = GetSetting("AMI_Optix", "Settings", "LiveSyncEnabled", "1")
-    g_AMIOptixLiveSyncEnabled = (Trim$(v) <> "0")
+    ' Fix-05: Manual Working Copy is always-on; live sync cannot be disabled.
+    g_AMIOptixLiveSyncEnabled = True
 
     m_LiveSyncInitialized = True
 End Sub
 
 Public Function GetLiveSyncEnabled() As Boolean
-    EnsureLiveSyncInitialized
-    GetLiveSyncEnabled = g_AMIOptixLiveSyncEnabled
+    ' Fix-05: Manual Working Copy is always-on; live sync cannot be disabled.
+    GetLiveSyncEnabled = True
 End Function
 
 Public Sub SetLiveSyncEnabled(enabled As Boolean)
     EnsureLiveSyncInitialized
-    g_AMIOptixLiveSyncEnabled = enabled
-    SaveSetting "AMI_Optix", "Settings", "LiveSyncEnabled", IIf(enabled, "1", "0")
+    ' Fix-05: Manual Working Copy is always-on; ignore requested state.
+    g_AMIOptixLiveSyncEnabled = True
 End Sub
 
 Public Sub Auto_Open()


### PR DESCRIPTION
Changes: removed Live Sync toggle; Manual Working Copy refreshes via /api/manual_calculate on AMI edits so invalid mixes are allowed (tradeoffs shown) and rent roll calcs update; added stronger event suppression to avoid re-entrant SheetChange loops. Tests: python -m pytest (51 passed); edge optimize sanity returned 4 scenarios for the test payload. Ready-to-deploy commit: 77f9b75.